### PR TITLE
Tune streamline

### DIFF
--- a/R_code/analysis/fit_random_forest/BSB.Classification.Recipe.R
+++ b/R_code/analysis/fit_random_forest/BSB.Classification.Recipe.R
@@ -59,8 +59,9 @@ BSB.Classification.Recipe <-BSB.Classification.Recipe %>%
 # RF doesn't benefit from normalization, so all I'm going to do is remove any 
 # zero variance predictors that might be hanging around. 
 BSB.Classification.Recipe <- BSB.Classification.Recipe %>% 
-  step_zv() 
-  
+  step_novel() %>%
+  step_zv(all_predictors())
+
 
 recipe_summary<-BSB.Classification.Recipe %>%
   summary() %>%

--- a/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
+++ b/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
@@ -39,11 +39,11 @@ tune_spec <- rand_forest(
              num.threads=!!my.ranger.threads, 
              na.action="na.learn", 
              respect.unordered.factors="order",
-             importance="permutation",
-             oob.error = TRUE,
-             keep.inbag=TRUE,
-             probability = TRUE,
-             write.forest=TRUE)
+             importance="none", # default, but I don't need importance for tuning.
+             oob.error = FALSE, # not used.
+             keep.inbag=FALSE, # default, but explicit 
+             probability = TRUE, # set to a probability model
+             write.forest=TRUE) # default, but explicity
 case_weights_allowed(tune_spec)
 
 

--- a/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
+++ b/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
@@ -36,7 +36,7 @@ tune_spec <- rand_forest(
 ) %>%
   set_mode("classification") %>%
   set_engine("ranger",
-             num.threads=!!my.ranger.threads, 
+             num.threads=!!my.ranger.multi.threads, 
              na.action="na.learn", 
              respect.unordered.factors="order",
              importance="none", # default, but I don't need importance for tuning.

--- a/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
+++ b/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
@@ -43,19 +43,23 @@ tune_spec <- rand_forest(
              oob.error = FALSE, # not used.
              keep.inbag=FALSE, # default, but explicit 
              probability = TRUE, # set to a probability model
-             write.forest=TRUE) # default, but explicity
+             write.forest=TRUE) # default, but explicit
 case_weights_allowed(tune_spec)
 
 
 # Use a workflow that combines the data processing recipe, assigns weights, and the model configuation
-BSB.Ranger.Workflow <-
+BSB.Ranger.tuning.Workflow <-
   workflow() %>%
   add_model(tune_spec) %>% 
   add_recipe(BSB.Classification.Recipe) %>%
   add_case_weights(weighting)
 
 
-hardhat::extract_parameter_set_dials(BSB.Ranger.Workflow)
+hardhat::extract_parameter_set_dials(BSB.Ranger.tuning.Workflow)
+
+finalized_params <- BSB.Ranger.tuning.Workflow %>%
+  extract_parameter_set_dials() %>%
+  finalize(train_data) 
 
 # pass in a bunch of metrics
 # if the recipe/workflow is case_weight aware, the metrics are also case-weight aware
@@ -67,34 +71,49 @@ class_and_probs_metrics <- metric_set(brier_class,mn_log_loss, roc_auc)
 # Set up a set of mtry to search over. 
 
 # I have about 40 predictors, so I'll specify a coarse initial grid with 25 points, 
-if  (search_type=="Initial"){
-  rf_grid<-  param_grid <- grid_space_filling(
-    mtry(range = c(5L, 35)),           # Number of variables per split
-    min_n(range = c(5L, 100L)),         # Minimum observations per node
-    size = 24                          # Grid size for initial exploration
+if (search_type == "Initial") {
+  
+  finalized_params<-finalized_params %>%
+    update(
+      mtry = mtry(range = c(5L, 35L)),   # override upper bound after finalization
+      min_n=min_n(range = c(5L, 100))  # minimum points in a leaf node
+    )
+  
+  rf_grid <- grid_space_filling(
+    finalized_params,   
+    size = 24                    # number of grid points for initial exploration
   )
 }
 
 # The initial grid search found an optimal min_n parameter on the boundary of my grid (min_n=100). 
 # Very small mtry and min_n did poorly, so did mtry approaching the number of factors, so I've tightened up the boundaries of the grid a bit.
 # And I've added 
-if  (search_type=="Advanced"){
-  rf_grid<-  param_grid <- grid_space_filling(
-    mtry(range = c(10L, 35)),           # Number of variables per split
-    min_n(range = c(10L, 300)),         # Minimum observations per node
-    size = 120                          # Grid size for initial exploration
-  )
+if (search_type == "Advanced") {
+  finalized_params<-finalized_params %>%
+    update(
+      mtry = mtry(range = c(10L, 35L)),   # override upper bound after finalization
+      min_n=min_n(range = c(10L, 300L))  # minimum points in a leaf nodee
+    )
   
+  rf_grid <- grid_space_filling(
+    finalized_params,   
+    size = 120                    # number of grid points for initial exploration
+  )
 }
-
 
 
 # Overwite mtry rf_grid for testing=true to speed prototyping
-if  (search_type=="Prototype"){
-  rf_grid<-  param_grid <- grid_space_filling(
-    mtry(range = c(2L, npredict)),           # Number of variables per split
-    min_n(range = c(5L, 50L)),         # Minimum observations per node
-    size = 4                          # Grid size for initial exploration
-  )
-}
 
+
+if (search_type == "Prototype") {
+  finalized_params<-finalized_params %>%
+    update(
+      mtry = mtry(range = c(2L, 8L)),   # override upper bound after finalization
+      min_n=min_n(range = c(5L, 50L))  # minimum points in a leaf node
+    )
+  
+  rf_grid <- grid_space_filling(
+    finalized_params,   
+    size = 4                    # number of grid points for initial exploration
+  )    
+}

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -7,8 +7,8 @@
 
 #Run from the project root
 Rscript --no-save --no-restore --verbose \
-  ./R_code/analysis/fit_random_forest/estimate_orandomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/h2o/estimate_orandomforest_nocluster.log
+  ./R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R \
+  2>&1 | stdbuf -oL -eL tee ./results/estimate_randomforest_nocluster.log
 
 
 # Rscript --no-save --no-restore --verbose ./estimate_5class_randomforest.R > estimate_5class_randomforest.log 2>&1

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -8,7 +8,7 @@
 #Run from the project root
 Rscript --no-save --no-restore --verbose \
   ./R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/estimate_randomforest_nocluster.log
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/estimate_randomforest_nocluster.log
 
 
 # Rscript --no-save --no-restore --verbose ./estimate_5class_randomforest.R > estimate_5class_randomforest.log 2>&1

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -30,7 +30,7 @@
 
 bayes_tune<-"FALSE"
 
-search_type<-"Initial"
+search_type<-"Prototype"
 # search_type in "Initial", "Prototype","Advanced")
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
@@ -79,6 +79,14 @@ conflicts_prefer(recipes::step())
 conflicts_prefer(viridis::viridis_pal())
 
 here::i_am("R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R")
+
+# Kill background logger if it is on
+system("pkill -f 'while true.*top'", ignore.stdout = TRUE, ignore.stderr = TRUE)
+message("CPU logger stopped")
+
+# start background logger
+source(here("R_code","analysis","helpers","background_logger.R"))
+
 
 
 # Determine what platform the code is running on and set the number of threads for ranger
@@ -196,7 +204,7 @@ keep_cols<-c(keep_cols,"MA7_gearQJumbo", "MA7_gearQLarge","MA7_gearQMedium", "MA
 keep_cols<-c(keep_cols,"MA7_stockarea_trips", "MA7_state_trips" )
 # keep_cols<-c(keep_cols,"Share2014Jumbo", "Share2014Large", "Share2014Medium","Share2014Small", "Share2014Unclassified" )
 # keep_cols<-c(keep_cols,"TransactionCountJumbo", "TransactionCountLarge", "TransactionCountMedium", "TransactionCountSmall", "TransactionCountUnclassified" )
-keep_cols<-c(keep_cols,"LagSharePoundsJumbo","LagSharePoundsLarge", "LagSharePoundsMedium","LagSharePoundsSmall")
+keep_cols<-c(keep_cols,"LagSharePoundsJumbo","LagSharePoundsLarge", "LagSharePoundsMedium","LagSharePoundsSmall", "first_dlr_year")
 #keep_cols<-c(keep_cols,"LagShareTransJumbo", "LagShareTransLarge", "LagShareTransMedium","LagShareTransSmall", "LagShareTransUnclassified")
 keep_cols<-c(keep_cols, "Price_Diff_J","Price_Diff_L", "Price_Diff_M") 
 
@@ -231,7 +239,7 @@ nrow(validation_data)
 # and predictor variables.
 source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
 
-
+# Set up the tuning workflow
 source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
 
 set.seed(123)
@@ -245,7 +253,7 @@ rf_control_grid<-control_grid(save_pred = TRUE, parallel_over="everything")
 start_time_tune<-Sys.time()
 
 tune_res <- tune_grid(
-  BSB.Ranger.Workflow,
+  BSB.Ranger.tuning.Workflow,
   resamples = myfolds,
   grid = rf_grid,
   control=rf_control_grid,
@@ -258,7 +266,7 @@ write_rds(tune_res, file=here("results","ranger", tune_file_name))
 end_time_tune<-Sys.time()
 end_time_tune-start_time_tune
 
-bayes_param <- BSB.Ranger.Workflow %>% 
+bayes_param <- BSB.Ranger.tuning.Workflow %>% 
   extract_parameter_set_dials() %>% 
   update(mtry = finalize(mtry(), train_data))
 
@@ -271,7 +279,7 @@ if(bayes_tune==TRUE){
   start_time_bt<-Sys.time()
   
   tune_res2 <- tune_bayes(
-    object=BSB.Ranger.Workflow,
+    object=BSB.Ranger.tuning.Workflow,
     resamples = myfolds,
     initial = tune_res,
     param_info=bayes_param,
@@ -307,16 +315,27 @@ tune_res2 %>%
 
 # Select the best Rforest based on log loss from the 10 folds.  Do a final fit on the full training dataset, predict on the validation dataset. Save the data
 
-best_tree <- tune_res2 %>%
+best_params <- tune_res2 %>%
   select_best(metric = "brier_class")
 
-best_tree
+best_params
+
+
+final_spec <- tune_spec %>%
+  finalize_model(best_params) %>%
+  set_engine("ranger",
+             num.threads = !!my.ranger.threads, 
+             na.action = "na.learn", 
+             respect.unordered.factors = "order",
+             importance = "permutation", # Turned ON for final variable importance
+             oob.error = FALSE,          # Kept OFF 
+             keep.inbag = FALSE,         # Kept OFF to save memory
+             probability = TRUE, 
+             write.forest = TRUE)
 
 # finalize model by picking the best model hyperparameters
-final_wf <- 
-  BSB.Ranger.Workflow %>% 
-  finalize_workflow(best_tree)
-
+final_wf  <- BSB.Ranger.tuning.Workflow %>%
+  update_model(final_spec)
 
 # Final model fitting on the full training dataset 
 final_fit <- 
@@ -337,5 +356,9 @@ end_time
 
 end_time-start_time
 sessionInfo()
+
+
+system("pkill -f 'while true.*top'", ignore.stdout = TRUE, ignore.stderr = TRUE)
+message("CPU logger stopped")
 
 cat("All done")

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -134,11 +134,13 @@ estimation_vintage<-as.character(Sys.Date())
 data_save_name<-glue("nocluster_data_split{estimation_vintage}.Rds")
 tune_file_name<-glue("BSB_ranger_nocluster_tune{estimation_vintage}.Rds")
 final_fit_file_name<-glue("BSB_ranger_nocluster_results{estimation_vintage}.Rds")
-
+vi_file_name<-glue("BSB_ranger_nocluster_VI{estimation_vintage}.Rds")
 if  (search_type=="Prototype"){
   data_save_name<-glue("nocluster_data_split_TEST{estimation_vintage}.Rds")
   tune_file_name<-glue("BSB_ranger_nocluster_tune_TEST{estimation_vintage}.Rds")
   final_fit_file_name<-glue("BSB_ranger_nocluster_results_TEST{estimation_vintage}.Rds")
+  vi_file_name<-glue("BSB_ranger_nocluster_VI_TEST{estimation_vintage}.Rds")
+  
   
 }
 
@@ -320,18 +322,52 @@ best_params <- tune_res2 %>%
 
 best_params
 
+# variable importance spec
+vi_spec <- tune_spec %>%
+  finalize_model(best_params) %>%
+  set_engine("ranger",
+             num.threads = !!my.ranger.threads, 
+             na.action = "na.learn", 
+             respect.unordered.factors = "order",
+             importance = "impurity_corrected", # While I'd prefer permutation, that relies on OOB. Impurity corrected is better.  
+             oob.error = FALSE,          # Kept OFF 
+             keep.inbag = FALSE,         # Kept OFF to save memory
+             probability = TRUE, 
+             write.forest = TRUE)
 
+# finalize model by picking the best model hyperparameters
+vi_wf  <- BSB.Ranger.tuning.Workflow %>%
+  update_model(vi_spec)
+
+# Final model fitting on the full training dataset 
+vi_fit <- 
+  vi_wf %>%
+  last_fit(data_split, metrics=class_and_probs_metrics) 
+
+
+
+
+vi_data<-vi_fit%>%
+  extract_fit_parsnip() %>%
+  vi(method = "model") 
+
+write_rds(final_fit, file=here("results","ranger",vi_file_name))
+
+############################################
+# variable importance spec
 final_spec <- tune_spec %>%
   finalize_model(best_params) %>%
   set_engine("ranger",
              num.threads = !!my.ranger.threads, 
              na.action = "na.learn", 
              respect.unordered.factors = "order",
-             importance = "permutation", # Turned ON for final variable importance
+             importance = "impurity_corrected", # While I'd prefer permutation, that relies on OOB. Impurity corrected is better.  
              oob.error = FALSE,          # Kept OFF 
              keep.inbag = FALSE,         # Kept OFF to save memory
              probability = TRUE, 
              write.forest = TRUE)
+
+
 
 # finalize model by picking the best model hyperparameters
 final_wf  <- BSB.Ranger.tuning.Workflow %>%

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -28,7 +28,7 @@
 # works.
 
 
-bayes_tune<-"FALSE"
+bayes_tune<-"TRUE"
 
 search_type<-"Prototype"
 # search_type in "Initial", "Prototype","Advanced")
@@ -65,7 +65,7 @@ library("knitr")
 library("kableExtra")
 library("viridis")
 library("future")
-		   
+library("vip")		   
 library("conflicted")
 
 #deal with conflicts
@@ -77,7 +77,7 @@ conflicts_prefer(yardstick::spec())
 conflicts_prefer(recipes::fixed())
 conflicts_prefer(recipes::step())
 conflicts_prefer(viridis::viridis_pal())
-
+conflicts_prefer(vip::vi)
 here::i_am("R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R")
 
 # Kill background logger if it is on
@@ -253,6 +253,7 @@ set.seed(8675309)
 
 rf_control_grid<-control_grid(save_pred = TRUE, parallel_over="everything")
 start_time_tune<-Sys.time()
+
 
 tune_res <- tune_grid(
   BSB.Ranger.tuning.Workflow,

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -28,12 +28,13 @@
 # works.
 
 
+bayes_tune<-"FALSE"
 
-search_type<-"Advanced"
+search_type<-"Initial"
 # search_type in "Initial", "Prototype","Advanced")
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
-#testing_fraction<-1					  
+testing_fraction<-0.3					  
 #  
 start_time<-Sys.time()
 modeltype<-"nocluster"
@@ -261,39 +262,47 @@ bayes_param <- BSB.Ranger.Workflow %>%
   extract_parameter_set_dials() %>% 
   update(mtry = finalize(mtry(), train_data))
 
+if(bayes_tune==TRUE){
+  
+  # Do a tune_bayes
+  plan("multisession", workers=my.parallel.threads)
+  set.seed(9035768)
+  
+  start_time_bt<-Sys.time()
+  
+  tune_res2 <- tune_bayes(
+    object=BSB.Ranger.Workflow,
+    resamples = myfolds,
+    initial = tune_res,
+    param_info=bayes_param,
+    iter = 30,                     # 
+    control = control_bayes(
+      verbose = TRUE,
+      no_improve=10,
+      save_pred = TRUE,             # Save predictions for analysis
+      save_workflow = FALSE,        # Save memory
+      extract = NULL,              # Don't extract additional info
+      parallel_over = "everything" # Parallelize over resamples to save memory
+      ),
+      metrics=metric_set(brier_class)
+  )
+  end_time_bt<-Sys.time()
+  end_time_bt-start_time_bt
+  
+  plan(sequential)
+  write_rds(tune_res2, file=here("results","ranger", tune_file_name))
+  
+  autoplot(tune_res2, type = "performance") +
+    labs(title = "Did Bayesian optimization converge?")
+}else if (bayes_tune==FALSE){
+  tune_res2<-tune_res
+}
 
-
-# Do a tune_bayes
-plan("multisession", workers=my.parallel.threads)
-set.seed(9035768)
-
-start_time_bt<-Sys.time()
-
-tune_res2 <- tune_bayes(
-  object=BSB.Ranger.Workflow,
-  resamples = myfolds,
-  initial = tune_res,
-  param_info=bayes_param,
-  iter = 30,                     # 
-  control = control_bayes(
-    verbose = TRUE,
-    no_improve=10,
-    save_pred = TRUE,             # Save predictions for analysis
-    save_workflow = FALSE,        # Save memory
-    extract = NULL,              # Don't extract additional info
-    parallel_over = "everything" # Parallelize over resamples to save memory
-    ),
-    metrics=metric_set(brier_class)
-)
-end_time_bt<-Sys.time()
-end_time_bt-start_time_bt
-
-plan(sequential)
-write_rds(tune_res2, file=here("results","ranger", tune_file_name))
-
-autoplot(tune_res2, type = "performance") +
-  labs(title = "Did Bayesian optimization converge?")
-
+tune_res2 %>%
+  tune::collect_notes() %>%
+  dplyr::filter(type == "error") %>%
+  dplyr::select(location, note) %>%
+  print(width = 200)
 
 
 # Select the best Rforest based on log loss from the 10 folds.  Do a final fit on the full training dataset, predict on the validation dataset. Save the data

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -28,13 +28,13 @@
 # works.
 
 
-bayes_tune<-"TRUE"
+bayes_tune<-"FALSE"
 
 search_type<-"Prototype"
 # search_type in "Initial", "Prototype","Advanced")
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
-testing_fraction<-0.3					  
+testing_fraction<-0.5					  
 #  
 start_time<-Sys.time()
 modeltype<-"nocluster"
@@ -106,16 +106,20 @@ if(platform == 'Windows'){
 }
 
 if (runClass %in% c('Local', 'Windows')){
-  my.parallel.threads<-parallel::detectCores() -2 
+  my.parallel.threads<-1
+  my.ranger.multi.threads<-5
 } else if (runClass %in% c('Container','DynamicContainer')){ 
-					  
-												
+	  
+	# on the container, you're allocated 24 threads	and 90 (or 96gb of memory)										
   my.parallel.threads<-4
+  my.ranger.multi.threads<-5
+  my.ranger.sequential.threads<-20
+  
   
 }
 my.ranger.threads<-5
 lbs_per_mt<-2204.62
-# a parallel instance here seems to use around 12-15gb of ram.  So 2 parallel and 7 threads uses about half of my ram, there's a little creep up.
+# my.parallel.threads =4 and my.ranger.multi.threads=5  about 30 GB of RAM on the "full" dataset (~381,542 in the training set).
 
 options(future.globals.maxSize = 2 * 1024^3)
 
@@ -254,6 +258,7 @@ set.seed(8675309)
 rf_control_grid<-control_grid(save_pred = TRUE, parallel_over="everything")
 start_time_tune<-Sys.time()
 
+message("Tuning model hyperparameters", Sys.time())
 
 tune_res <- tune_grid(
   BSB.Ranger.tuning.Workflow,
@@ -262,7 +267,8 @@ tune_res <- tune_grid(
   control=rf_control_grid,
   metrics=class_and_probs_metrics
 )
-plan(sequential)
+plan("sequential")
+message("Grid Tuning Finished", Sys.time())
 
 
 write_rds(tune_res, file=here("results","ranger", tune_file_name))
@@ -274,6 +280,7 @@ bayes_param <- BSB.Ranger.tuning.Workflow %>%
   update(mtry = finalize(mtry(), train_data))
 
 if(bayes_tune==TRUE){
+message("Performing Bayesian Tuning", Sys.time())
   
   # Do a tune_bayes
   plan("multisession", workers=my.parallel.threads)
@@ -300,12 +307,15 @@ if(bayes_tune==TRUE){
   end_time_bt<-Sys.time()
   end_time_bt-start_time_bt
   
-  plan(sequential)
+  plan("sequential")
   write_rds(tune_res2, file=here("results","ranger", tune_file_name))
+  message("Bayesian Tuning Finished", Sys.time())
   
   autoplot(tune_res2, type = "performance") +
     labs(title = "Did Bayesian optimization converge?")
 }else if (bayes_tune==FALSE){
+  message("Bayesian Tuning Skipped")
+  
   tune_res2<-tune_res
 }
 
@@ -328,10 +338,14 @@ best_params
 # Therefore, we fit the model once to get the proper variable importance, then we refit to get the true 'last model' for predictions.
 ########################################################################################################
 # variable importance spec
+
+# A threading note 
+# here I'm fitting an RF on a single set of params (there's 1 mtry and 1 num_trees). I could run a multisession, but just allocating alot of threads to ranger will work fine too.
+
 vi_spec <- tune_spec %>%
   finalize_model(best_params) %>%
   set_engine("ranger",
-             num.threads = !!my.ranger.threads, 
+             num.threads = !!my.ranger.sequential.threads, 
              na.action = "na.learn", 
              respect.unordered.factors = "order",
              importance = "impurity_corrected", # While I'd prefer permutation, that relies on OOB. Impurity corrected is better.  
@@ -345,7 +359,9 @@ vi_wf  <- BSB.Ranger.tuning.Workflow %>%
   update_model(vi_spec)
 
 set.seed(132564)
+
 # Final model fitting on the full training dataset 
+message("Fitting model to estimate variable importance.", Sys.time())
 vi_fit <- 
   vi_wf %>%
   last_fit(data_split, metrics=class_and_probs_metrics) 
@@ -356,6 +372,7 @@ vi_fit <-
 vi_data<-vi_fit%>%
   extract_fit_parsnip() %>%
   vi(method = "model") 
+message("Variable Importance Model fit finished", Sys.time())
 
 write_rds(vi_data, file=here("results","ranger",vi_file_name))
 ########################################################################################################
@@ -366,7 +383,7 @@ write_rds(vi_data, file=here("results","ranger",vi_file_name))
 final_spec <- tune_spec %>%
   finalize_model(best_params) %>%
   set_engine("ranger",
-             num.threads = !!my.ranger.threads, 
+             num.threads = !!my.ranger.sequential.threads, 
              na.action = "na.learn", 
              respect.unordered.factors = "order",
              importance = "impurity_corrected", # While I'd prefer permutation, that relies on OOB. Impurity corrected is better.  
@@ -383,10 +400,12 @@ final_wf  <- BSB.Ranger.tuning.Workflow %>%
 set.seed(132564)
 
 # Final model fitting on the full training dataset 
+message("Fitting final model:...")
 final_fit <- 
   final_wf %>%
   last_fit(data_split, metrics=class_and_probs_metrics) 
 
+message("Final model fit finished.", Sys.time())
 
 
 write_rds(final_fit, file=here("results","ranger",final_fit_file_name))

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -111,9 +111,9 @@ if (runClass %in% c('Local', 'Windows')){
 } else if (runClass %in% c('Container','DynamicContainer')){ 
 	  
 	# on the container, you're allocated 24 threads	and 90 (or 96gb of memory)
-  # Because the dataset is big, you are much better off doing 2 and 10 (or 1 and 22)
+  # Because the dataset is big, you are much better off doing 2 and 11 (or 1 and 22)
   my.parallel.threads<-2
-  my.ranger.multi.threads<-10
+  my.ranger.multi.threads<-11
   my.ranger.sequential.threads<-20
   
   

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -30,11 +30,11 @@
 
 bayes_tune<-"FALSE"
 
-search_type<-"Prototype"
+search_type<-"Initial"
 # search_type in "Initial", "Prototype","Advanced")
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
-testing_fraction<-0.5					  
+testing_fraction<-1			  
 #  
 start_time<-Sys.time()
 modeltype<-"nocluster"
@@ -110,9 +110,10 @@ if (runClass %in% c('Local', 'Windows')){
   my.ranger.multi.threads<-5
 } else if (runClass %in% c('Container','DynamicContainer')){ 
 	  
-	# on the container, you're allocated 24 threads	and 90 (or 96gb of memory)										
-  my.parallel.threads<-4
-  my.ranger.multi.threads<-5
+	# on the container, you're allocated 24 threads	and 90 (or 96gb of memory)
+  # Because the dataset is big, you are much better off doing 2 and 10 (or 1 and 22)
+  my.parallel.threads<-2
+  my.ranger.multi.threads<-10
   my.ranger.sequential.threads<-20
   
   

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -322,7 +322,11 @@ best_params <- tune_res2 %>%
   select_best(metric = "brier_class")
 
 best_params
-
+########################################################################################################
+# Final fit with impurity_correction.  Permutation is better, but an uncount() handling of weighted observations makes the 
+# OOB not truly "out of the bag".  Impurity corrected is the next best alternative, however it is not appropriate for predictions.
+# Therefore, we fit the model once to get the proper variable importance, then we refit to get the true 'last model' for predictions.
+########################################################################################################
 # variable importance spec
 vi_spec <- tune_spec %>%
   finalize_model(best_params) %>%
@@ -354,9 +358,11 @@ vi_data<-vi_fit%>%
   vi(method = "model") 
 
 write_rds(vi_data, file=here("results","ranger",vi_file_name))
+########################################################################################################
+########################################################################################################
 
 ############################################
-# variable importance spec
+# Final fit spec
 final_spec <- tune_spec %>%
   finalize_model(best_params) %>%
   set_engine("ranger",

--- a/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/estimate_randomforest_nocluster.R
@@ -340,6 +340,7 @@ vi_spec <- tune_spec %>%
 vi_wf  <- BSB.Ranger.tuning.Workflow %>%
   update_model(vi_spec)
 
+set.seed(132564)
 # Final model fitting on the full training dataset 
 vi_fit <- 
   vi_wf %>%
@@ -352,7 +353,7 @@ vi_data<-vi_fit%>%
   extract_fit_parsnip() %>%
   vi(method = "model") 
 
-write_rds(final_fit, file=here("results","ranger",vi_file_name))
+write_rds(vi_data, file=here("results","ranger",vi_file_name))
 
 ############################################
 # variable importance spec
@@ -373,6 +374,7 @@ final_spec <- tune_spec %>%
 # finalize model by picking the best model hyperparameters
 final_wf  <- BSB.Ranger.tuning.Workflow %>%
   update_model(final_spec)
+set.seed(132564)
 
 # Final model fitting on the full training dataset 
 final_fit <- 

--- a/R_code/analysis/helpers/background_logger.R
+++ b/R_code/analysis/helpers/background_logger.R
@@ -1,0 +1,14 @@
+# Start background logger
+r_user <- system("whoami", intern = TRUE)
+perf_log_file <- here("R_code", "analysis", "fit_random_forest","perf_usage.log")
+system(
+  paste0(
+    "bash -c 'while true; do ",
+    "CPU=$(top -bn2 -d0.5 | grep Cpu | tail -1 | awk \"{print \\$2+\\$4}\"); ",
+    "MEM=$(ps -u ", r_user, " --no-headers -o rss | awk \"{sum+=\\$1} END {print sum/1024}\"); ",
+    "echo \"$(date +%H:%M:%S) CPU: ${CPU}% MEM: ${MEM}MB\"; ",
+    "sleep 30; done' > ", perf_log_file, " 2>&1 &"
+  )
+)
+message("Performance logger started for user: ", r_user, ", writing to: ", perf_log_file)
+

--- a/R_code/analysis/helpers/modeltype_patterns.R
+++ b/R_code/analysis/helpers/modeltype_patterns.R
@@ -1,0 +1,19 @@
+# set data patterns based on modeltype
+# You've estimated a few difference models, this sets the 
+
+if (modeltype=="standard"){
+  data_pattern<-"data_split"
+  tuning_pattern<-"BSB_ranger_tune"
+  final_pattern<-"BSB_ranger_results"
+} else if (modeltype=="nocluster"){
+  data_pattern<-"nocluster_data_split"
+  tuning_pattern<-"BSB_ranger_nocluster_tune"
+  final_pattern<-"BSB_ranger_nocluster_results"
+} else if (modeltype=="noclusterTEST"){
+  data_pattern<-"nocluster_data_split_TEST"
+  tuning_pattern<-"BSB_ranger_nocluster_tune_TEST"
+  final_pattern<-"BSB_ranger_nocluster_results_TEST"
+}else {
+  stop("Unknown modeltype")
+}
+

--- a/R_code/analysis/helpers/modeltype_patterns.R
+++ b/R_code/analysis/helpers/modeltype_patterns.R
@@ -5,14 +5,20 @@ if (modeltype=="standard"){
   data_pattern<-"data_split"
   tuning_pattern<-"BSB_ranger_tune"
   final_pattern<-"BSB_ranger_results"
+  vi_pattern<-glue("BSB_ranger_nocluster")
+  
 } else if (modeltype=="nocluster"){
   data_pattern<-"nocluster_data_split"
   tuning_pattern<-"BSB_ranger_nocluster_tune"
   final_pattern<-"BSB_ranger_nocluster_results"
+  vi_pattern<-glue("BSB_ranger_nocluster_VI")
+  
 } else if (modeltype=="noclusterTEST"){
   data_pattern<-"nocluster_data_split_TEST"
   tuning_pattern<-"BSB_ranger_nocluster_tune_TEST"
   final_pattern<-"BSB_ranger_nocluster_results_TEST"
+  vi_pattern<-glue("BSB_ranger_nocluster_VI_TEST")
+  
 }else {
   stop("Unknown modeltype")
 }

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -14,10 +14,10 @@ editor_options:
 fontsize: 12pt
 params:
   modeltype:
-    value: nocluster
+    value: noclusterTEST
     choices:
     - nocluster
-    - TS_nocluster
+    - noclusterTEST
 ---
 
 # Summary and Housekeeping
@@ -134,10 +134,10 @@ if (modeltype=="standard"){
   data_pattern<-"nocluster_data_split"
   tuning_pattern<-"BSB_ranger_nocluster_tune"
   final_pattern<-"BSB_ranger_nocluster_results"
-} else if (modeltype=="TS_nocluster"){
-  data_pattern<-"nocluster_TS_data_split"
-  tuning_pattern<-"BSB_ranger_TS_nocluster_tune"
-  final_pattern<-"BSB_ranger_TS_nocluster_results"
+} else if (modeltype=="noclusterTEST"){
+  data_pattern<-"nocluster_data_split_TEST"
+  tuning_pattern<-"BSB_ranger_nocluster_tune_TEST"
+  final_pattern<-"BSB_ranger_nocluster_results_TEST"
 }else {
   stop("Unknown modeltype")
 }

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -124,24 +124,8 @@ my.ranger.threads<-7
 
 here::i_am("writing/calibration_and_validation.Rmd")
 
-
-# You've estimated a few difference models, this sets the 
-if (modeltype=="standard"){
-  data_pattern<-"data_split"
-  tuning_pattern<-"BSB_ranger_tune"
-  final_pattern<-"BSB_ranger_results"
-} else if (modeltype=="nocluster"){
-  data_pattern<-"nocluster_data_split"
-  tuning_pattern<-"BSB_ranger_nocluster_tune"
-  final_pattern<-"BSB_ranger_nocluster_results"
-} else if (modeltype=="noclusterTEST"){
-  data_pattern<-"nocluster_data_split_TEST"
-  tuning_pattern<-"BSB_ranger_nocluster_tune_TEST"
-  final_pattern<-"BSB_ranger_nocluster_results_TEST"
-}else {
-  stop("Unknown modeltype")
-}
-
+#handle model patterns
+source(here("R_code","analysis","helpers","modeltype_patterns.R"))
 
 
 

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -231,9 +231,11 @@ Look at the VIP, ROC, and PR curves
 ```{r VIP}
 # Look at variable importance. I want to see all the predictors.
 # The scale is different from previous versions, because I switched the variable importance method in the Workflow/recipe to "Permutation"
-vi_data <- final_fit %>%
-  extract_fit_parsnip() %>%
-  vi(method = "model") %>%          # pulls ranger's permutation importance
+
+vi_data<-read_rds(file=here("results","ranger",glue("{vi_pattern}{finalfit_vintage}.Rds")))
+
+
+vi_data <- vi_data %>%
   #slice_max(Importance, n = 20) %>% # top 20 only at single-column width
   mutate(
     Variable = forcats::fct_reorder(Variable, Importance),

--- a/writing/final_fit.Rmd
+++ b/writing/final_fit.Rmd
@@ -18,10 +18,10 @@ editor_options:
 fontsize: 12pt
 params:
   modeltype:
-    value: nocluster
+    value: noclusterTEST
     choices:
     - nocluster
-    - TS_nocluster
+    - noclusterTEST
 ---
 
 # Summary and Housekeeping
@@ -130,23 +130,7 @@ my.ranger.threads<-7
 
 here::i_am("writing/final_fit.Rmd")
 
-
-# You've estimated a few difference models, this sets the 
-if (modeltype=="standard"){
-  data_pattern<-"data_split"
-  tuning_pattern<-"BSB_ranger_tune"
-  final_pattern<-"BSB_ranger_results"
-} else if (modeltype=="nocluster"){
-  data_pattern<-"nocluster_data_split"
-  tuning_pattern<-"BSB_ranger_nocluster_tune"
-  final_pattern<-"BSB_ranger_nocluster_results"
-} else if (modeltype=="TS_nocluster"){
-  data_pattern<-"nocluster_TS_data_split"
-  tuning_pattern<-"BSB_ranger_TS_nocluster_tune"
-  final_pattern<-"BSB_ranger_TS_nocluster_results"
-}else {
-  stop("Unknown modeltype")
-}
+source(here("R_code","analysis","helpers","modeltype_patterns.R"))
 
 
 

--- a/writing/out_of_sample_predictions.Rmd
+++ b/writing/out_of_sample_predictions.Rmd
@@ -129,23 +129,8 @@ my.ranger.threads<-7
 
 here::i_am("writing/out_of_sample_predictions.Rmd")
 
-
-# You've estimated a few difference models, this sets the 
-if (modeltype=="standard"){
-  data_pattern<-"data_split"
-  tuning_pattern<-"BSB_ranger_tune"
-  final_pattern<-"BSB_ranger_results"
-} else if (modeltype=="nocluster"){
-  data_pattern<-"nocluster_data_split"
-  tuning_pattern<-"BSB_ranger_nocluster_tune"
-  final_pattern<-"BSB_ranger_nocluster_results"
-} else if (modeltype=="TS_nocluster"){
-  data_pattern<-"nocluster_TS_data_split"
-  tuning_pattern<-"BSB_ranger_TS_nocluster_tune"
-  final_pattern<-"BSB_ranger_TS_nocluster_results"
-}else {
-  stop("Unknown modeltype")
-}
+#handle model patterns
+source(here("R_code","analysis","helpers","modeltype_patterns.R"))
 
 
 

--- a/writing/predictions_heatmap.Rmd
+++ b/writing/predictions_heatmap.Rmd
@@ -116,24 +116,8 @@ my.ranger.threads<-7
 
 here::i_am("writing/predictions_heatmap.Rmd")
 
-
-# You've estimated a few difference models, this sets the 
-if (modeltype=="standard"){
-  data_pattern<-"data_split"
-  tuning_pattern<-"BSB_ranger_tune"
-  final_pattern<-"BSB_ranger_results"
-} else if (modeltype=="nocluster"){
-  data_pattern<-"nocluster_data_split"
-  tuning_pattern<-"BSB_ranger_nocluster_tune"
-  final_pattern<-"BSB_ranger_nocluster_results"
-} else if (modeltype=="TS_nocluster"){
-  data_pattern<-"nocluster_TS_data_split"
-  tuning_pattern<-"BSB_ranger_TS_nocluster_tune"
-  final_pattern<-"BSB_ranger_TS_nocluster_results"
-}else {
-  stop("Unknown modeltype")
-}
-
+#handle model patterns
+source(here("R_code","analysis","helpers","modeltype_patterns.R"))
 
 
 


### PR DESCRIPTION
In the tune_spec, I've set importance=none, oob.error=FALSE, and keep.inbag=FALSE. I don't use these during tuning, so we're just doing more computations and using extra disk space for no reason.


- Name the tuning.workflow explicitly.
- Added a helper file that handles data patterns. 
- Added some messages to print where we are in the code
- Adjust the threading.

brings over some lessons learned and utilities from the ill-fated h2o exploration

1. A the batch file is re-written to output immediately to a log. This ensures we capture all errors.
2. Adjusted recipe to add step_novel() and an explicit all_predictors()
3. Brought over the hardhat::finalization code and added it to the 'grid'
4. Added a cut-out for bayes_tune.
5. Added a CPU and memory usage logger.


