### PR TITLE
Weighting post training

### DIFF
--- a/R_code/analysis/fit_random_forest/BSB.Classification.Recipe.R
+++ b/R_code/analysis/fit_random_forest/BSB.Classification.Recipe.R
@@ -58,9 +58,8 @@ BSB.Classification.Recipe <-BSB.Classification.Recipe %>%
 # You can't center the factor variables
 # RF doesn't benefit from normalization, so all I'm going to do is remove any 
 # zero variance predictors that might be hanging around. 
-BSB.Classification.Recipe <- BSB.Classification.Recipe %>% 
-  step_novel() %>%
-  step_zv(all_predictors())
+#BSB.Classification.Recipe <- BSB.Classification.Recipe %>% 
+#  step_zv(all_predictors())
 
 
 recipe_summary<-BSB.Classification.Recipe %>%

--- a/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
+++ b/R_code/analysis/fit_random_forest/BSB.Workflow.Setup.R
@@ -48,6 +48,7 @@ tune_spec <- rand_forest(
              verbose=TRUE) # default, but explicit
 
 
+
 # Use a workflow that combines the data processing recipe, assigns weights, and the model configuation
 BSB.Ranger.tuning.Workflow <-
   workflow() %>%

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -7,13 +7,13 @@ set -o pipefail
 #   2>&1 | stdbuf -oL -eL tee ./results/ranger/tune_randomforest_nocluster.log #\
 #&& \
 # Train \
- Rscript --no-save --no-restore --verbose \
-   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R >  \
-   ./results/ranger/train_randomforest_nocluster.log 2>&1
-
+Rscript --no-save --no-restore --verbose \
+  ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log \
+&& \
 # Fit the Variable importance 
  Rscript --no-save --no-restore --verbose \
-   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R >  \
-   ./results/ranger/variable_importance_randomforest_nocluster.log 2>&1
+   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log
 
 

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -9,11 +9,11 @@ set -o pipefail
 # Train \
 Rscript --no-save --no-restore --verbose \
   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log \
-&& \
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log #\
+#&& \
 # Fit the Variable importance 
- Rscript --no-save --no-restore --verbose \
-   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log
+# Rscript --no-save --no-restore --verbose \
+#   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
+#  2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log
 
 

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -7,10 +7,10 @@ set -o pipefail
 #   2>&1 | stdbuf -oL -eL tee ./results/ranger/tune_randomforest_nocluster.log #\
 #&& \
 # Train \
-Rscript --no-save --no-restore --verbose \
-  ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log \
-&& \
+#Rscript --no-save --no-restore --verbose \
+#  ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
+#  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log #\
+#&& \
 # Fit the Variable importance 
  Rscript --no-save --no-restore --verbose \
    ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -1,23 +1,19 @@
 #!/bin/bash
 set -o pipefail
-# batch file to run a bunch of RF models over the weekend
-#Rscript --no-save --no-restore --verbose ./estimate_randomforest_nocluster_Tsubset.R > estimate_randomforest_nocluster_Tsubset.log 2>&1
+# batch file to the Tune, train, Variable importance code
+# Tune. Run from the project root
+# Rscript --no-save --no-restore --verbose \
+#   ./R_code/analysis/fit_random_forest/tune_randomforest_nocluster.R \
+#   2>&1 | stdbuf -oL -eL tee ./results/ranger/tune_randomforest_nocluster.log #\
+#&& \
+# Train \
+ # Rscript --no-save --no-restore --verbose \
+ #   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
+ #   2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log\
 
-#Rscript --no-save --no-restore --verbose ./estimate_randomforest_nocluster.R > estimate_randomforest_nocluster.log 2>&1
-
-#Run from the project root
+# Fit the Variable importance 
  Rscript --no-save --no-restore --verbose \
-   ./R_code/analysis/fit_random_forest/tune_randomforest_nocluster.R \
-   2>&1 | stdbuf -oL -eL tee ./results/ranger/tune_randomforest_nocluster.log\
- && \
-Rscript --no-save --no-restore --verbose \
-  ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log\
+   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
+   2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log\
 
 
-# Rscript --no-save --no-restore --verbose ./estimate_5class_randomforest.R > estimate_5class_randomforest.log 2>&1
-
- 
-#Rscript --no-save --no-restore --verbose ./estimate_randomforest_RegionN_nocluster.R > estimate_randomforest_RegionN_nocluster.log 2>&1
-
-# Rscript --no-save --no-restore --verbose  ./estimate_randomforest.R > estimate_randomforest.log 2>&1

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -9,11 +9,11 @@ set -o pipefail
 # Train \
 Rscript --no-save --no-restore --verbose \
   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
-  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log #\
-#&& \
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log \
+&& \
 # Fit the Variable importance 
-# Rscript --no-save --no-restore --verbose \
-#   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
-#  2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log
+ Rscript --no-save --no-restore --verbose \
+   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
+  2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log
 
 

--- a/R_code/analysis/fit_random_forest/batch_RF_run.sh
+++ b/R_code/analysis/fit_random_forest/batch_RF_run.sh
@@ -7,13 +7,13 @@ set -o pipefail
 #   2>&1 | stdbuf -oL -eL tee ./results/ranger/tune_randomforest_nocluster.log #\
 #&& \
 # Train \
- # Rscript --no-save --no-restore --verbose \
- #   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R \
- #   2>&1 | stdbuf -oL -eL tee ./results/ranger/train_randomforest_nocluster.log\
+ Rscript --no-save --no-restore --verbose \
+   ./R_code/analysis/fit_random_forest/train_randomforest_nocluster.R >  \
+   ./results/ranger/train_randomforest_nocluster.log 2>&1
 
 # Fit the Variable importance 
  Rscript --no-save --no-restore --verbose \
-   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R \
-   2>&1 | stdbuf -oL -eL tee ./results/ranger/variable_importance_randomforest_nocluster.log\
+   ./R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R >  \
+   ./results/ranger/variable_importance_randomforest_nocluster.log 2>&1
 
 

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -213,7 +213,7 @@ selected_params<-tm[2,] %>%
 # Use update to change trees, 
 # finalize the model with best_params
 final_spec <- tune_spec %>%
-  update(trees=20)%>%
+  update(trees=500)%>%
   finalize_model(selected_params)
 
 # I have to adjust the arguments this way or I have to rewrite the entire workflow

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -151,45 +151,6 @@ best_param_file_name<-glue("{best_param_pattern}{tuning_vintage}.Rds")
 final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
 vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
 
-
-data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
-# do not read in the test data
-
-train_data <- training(data_split)
-calibration_data <- validation(data_split)
-rm(data_split)
-
-nrow(train_data)
-
-nrow(calibration_data)
-
-train_raw_rows<-nrow(train_data)
-
-
-#expand by landed pounds 
-#replacing "in place" so that there's no chance the recipe fits to the wrong data.
-train_data<-train_data %>%
-  select(-c(price,priceR_CPI, dlrid, myl_id)) %>%
-  mutate(lndlb2=lndlb) %>%
-  uncount(lndlb2)
-
-train_expand_rows<-nrow(train_data)
-
-
-
-message("Original training dataset :", train_raw_rows )
-message("Training dataset rows (expanded):", train_expand_rows )
-
-
-# # Recipe definition
-# 
-# The recipe simply defines the dataset, outcome (reponse, y) variable, id variables,
-# and predictor variables.
-source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
-
-# Set up the tuning workflow
-source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
-
 # Read in best parameters.  Do a training on the full training dataset, predict on the calibration dataset. 
 
 #tune_res<-read_rds(file=here("results","ranger", tune_file_name))
@@ -204,6 +165,52 @@ tm<-fold_results  %>%
 
 selected_params<-tm[2,] %>%
   select(-mt)
+rm(fold_results)
+
+
+
+
+data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+# do not read in the test data
+
+train_data <- training(data_split)
+#calibration_data <- validation(data_split)
+rm(data_split)
+
+#nrow(train_data)
+
+#nrow(calibration_data)
+
+train_raw_rows<-nrow(train_data)
+
+
+train_data<-train_data %>%
+  select(-c(price,priceR_CPI, dlrid, myl_id))
+
+
+
+
+
+# # Recipe definition
+# 
+# The recipe simply defines the dataset, outcome (reponse, y) variable, id variables,
+# and predictor variables.
+source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
+
+
+# Set up the tuning workflow
+source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
+
+
+#expand by landed pounds 
+#replacing "in place" so that there's no chance the recipe fits to the wrong data.
+train_data<-train_data %>% 
+  mutate(lndlb2=lndlb) %>%
+  uncount(lndlb2)
+
+train_expand_rows<-nrow(train_data)
+message("Original training dataset :", train_raw_rows )
+message("Training dataset rows (expanded):", train_expand_rows )
 
 
 
@@ -220,7 +227,7 @@ final_spec <- tune_spec %>%
 # Verbose=TRUE to monitor what is going on.
 # save.memory slows it way down, but writes trees to disk to save on memory.
 final_spec$eng_args$verbose<-rlang::quo(TRUE)
-final_spec$eng_args$save.memory<-rlang::quo(TRUE)
+#final_spec$eng_args$save.memory<-rlang::quo(TRUE)
 
 # finalize model by setting best model hyperparameters
 final_wf_spec  <- BSB.Ranger.tuning.Workflow %>%
@@ -228,7 +235,7 @@ final_wf_spec  <- BSB.Ranger.tuning.Workflow %>%
 set.seed(132564)
 
 # clean up
-rm(BSB.Ranger.tuning.Workflow)
+rm(BSB.Ranger.tuning.Workflow, recipe_summary, tm, tune_spec, rf_grid)
 gc()
 
 fit_control<-control_parsnip(verbosity = 2L, catch = FALSE)
@@ -267,11 +274,14 @@ train_metrics
 message("End Fit metrics")
 
 
+# calibration predictions
+data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
 
-
+calibration_data <- validation(data_split)
+rm(data_split)
 
 #prediction using the validation data 
-calib_preds <- augment(final_fit, new_data = calibration_data)
+calib_preds <- augment(final_fit, new_data = calibration_baked)
 
 # print out the metrics
 

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -153,14 +153,15 @@ vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
 
 
 data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+# do not read in the test data
 
 train_data <- training(data_split)
-validation_data <- validation(data_split)
+calibration_data <- validation(data_split)
 rm(data_split)
 
 nrow(train_data)
 
-nrow(validation_data)
+nrow(calibration_data)
 
 train_raw_rows<-nrow(train_data)
 
@@ -189,7 +190,7 @@ source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R
 # Set up the tuning workflow
 source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
 
-# Read in best parameters.  Do a training on the full training dataset, predict on the validation dataset. Save the data
+# Read in best parameters.  Do a training on the full training dataset, predict on the calibration dataset. 
 
 #tune_res<-read_rds(file=here("results","ranger", tune_file_name))
 best_params<-read_rds(file=here("results","ranger", best_param_file_name))

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -249,13 +249,13 @@ train_preds <- augment(final_fit, new_data = train_data)
 
 
 train_metrics <- bind_rows(
-  roc_auc(calib_preds, truth = market_desc, 
+  roc_auc(train_preds, truth = market_desc, 
           starts_with(".pred_")
   ),
-  mn_log_loss(calib_preds, truth = market_desc,
+  mn_log_loss(train_preds, truth = market_desc,
               starts_with(".pred_")
   ),
-  brier_class(calib_preds, truth = market_desc,
+  brier_class(train_preds, truth = market_desc,
               starts_with(".pred_")
   )
   

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -249,7 +249,9 @@ train_expanded<-train_data %>%
   mutate(lndlb2=lndlb) %>%
   uncount(lndlb2)
 
-train_expand_rows<-nrow(train_data)
+train_raw_rows<-nrow(train_data)
+train_expand_rows<-nrow(train_expanded)
+
 message("Original training dataset :", train_raw_rows )
 message("Training dataset rows (expanded):", train_expand_rows )
 

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -63,6 +63,7 @@ search_type<-"Advanced"
 
 
 source(here("R_code","analysis","helpers","modeltype_patterns.R"))
+source(here("R_code","analysis","helpers","predict_byhand.R"))
 
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
@@ -107,7 +108,6 @@ if (runClass %in% c('Local', 'Windows')){
 }
 lbs_per_mt<-2204.62
 
-lbs_per_mt<-2204.62
 #############################################################################
 my_images<-here("images")
 descriptive_images<-here("images","descriptive")
@@ -151,6 +151,9 @@ best_param_file_name<-glue("{best_param_pattern}{tuning_vintage}.Rds")
 final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
 vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
 
+prepped_recipe_file_name<-glue("{prepped_recipe}{tuning_vintage}.Rds")
+calib_dataset_name<-glue("{calib_data_pattern}{tuning_vintage}.Rds")
+
 # Read in best parameters.  Do a training on the full training dataset, predict on the calibration dataset. 
 
 #tune_res<-read_rds(file=here("results","ranger", tune_file_name))
@@ -177,12 +180,13 @@ train_data <- training(data_split)
 #calibration_data <- validation(data_split)
 rm(data_split)
 
-#nrow(train_data)
+# train_data$rand<-runif(nrow(train_data))
+# train_data<-train_data %>%
+#  dplyr::filter(rand<=.05)%>%
+#  select(-rand)
 
-#nrow(calibration_data)
 
 train_raw_rows<-nrow(train_data)
-
 
 train_data<-train_data %>%
   select(-c(price,priceR_CPI, dlrid, myl_id))
@@ -197,14 +201,51 @@ train_data<-train_data %>%
 # and predictor variables.
 source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
 
+# I need to handle the prep and bake the recipe manually, instead of using a workflow.
 
+prepped_recipe <- prep(
+  BSB.Classification.Recipe,
+  training = train_data,
+  retain   = FALSE        # <--save memory 
+)
+
+write_rds(prepped_recipe, file=here("results","ranger",prepped_recipe_file_name))
+
+# I need to do the workflow manually to save memory
 # Set up the tuning workflow
-source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
+# source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
+
+
+# configure the final_spec
+final_spec <- rand_forest(
+  trees = 500,
+  mtry = tune(),
+  min_n = tune(),
+) %>%
+  set_mode("classification") %>%
+  set_engine("ranger",
+             num.threads=!!my.ranger.sequential.threads, 
+             na.action="na.learn", 
+             respect.unordered.factors="order",
+             importance="none", # default, but I don't need importance for tuning.
+             oob.error = FALSE, # not used.
+             keep.inbag=FALSE, # default, but explicit 
+             probability = TRUE, # set to a probability model
+             write.forest=TRUE,
+             save.memory=TRUE,
+             verbose=TRUE,  # default, but explicit 
+             seed= 132564) %>% 
+  finalize_model(selected_params) 
+
+#Print the ranger call
+translate(final_spec)
+
+#Not currently used for training, but keeping it around
+class_and_probs_metrics <- metric_set(brier_class,mn_log_loss, roc_auc)
 
 
 #expand by landed pounds 
-#replacing "in place" so that there's no chance the recipe fits to the wrong data.
-train_data<-train_data %>% 
+train_expanded<-train_data %>% 
   mutate(lndlb2=lndlb) %>%
   uncount(lndlb2)
 
@@ -212,85 +253,118 @@ train_expand_rows<-nrow(train_data)
 message("Original training dataset :", train_raw_rows )
 message("Training dataset rows (expanded):", train_expand_rows )
 
+# Apply 
+train_baked <- bake(
+  prepped_recipe,
+  new_data = train_expanded)
 
 
-
-############################################
-# Final fit spec
-# Use update to change trees, 
-# finalize the model with best_params
-final_spec <- tune_spec %>%
-  update(trees=500)%>%
-  finalize_model(selected_params)
-
-# I have to adjust the arguments this way or I have to rewrite the entire workflow
-# Verbose=TRUE to monitor what is going on.
-# save.memory slows it way down, but writes trees to disk to save on memory.
-final_spec$eng_args$verbose<-rlang::quo(TRUE)
-#final_spec$eng_args$save.memory<-rlang::quo(TRUE)
-
-# finalize model by setting best model hyperparameters
-final_wf_spec  <- BSB.Ranger.tuning.Workflow %>%
-  update_model(final_spec)
-set.seed(132564)
-
-# clean up
-rm(BSB.Ranger.tuning.Workflow, recipe_summary, tm, tune_spec, rf_grid)
+rm(train_data, train_expanded)
 gc()
+############################################
 
-fit_control<-control_parsnip(verbosity = 2L, catch = FALSE)
-
-# Final model fitting on the full training dataset 
+# Final model fitting on the baked dataset
 message("Fitting final model:...")
-final_fit <- 
-  final_wf_spec %>%
-  fit(train_data)
+final_ranger_fit <- ranger(
+  market_desc ~ .,                              # outcome ~ all remaining columns
+  data                      = train_baked,
+  num.trees                 = 500,              # full 500 trees (memory budget allows)
+  mtry                      = selected_params$mtry,
+  min.node.size             = selected_params$min_n,
+  probability               = TRUE,            # required: returns class probabilities
+  num.threads              =  my.ranger.sequential.threads, 
+  respect.unordered.factors = "order",
+  na.action                 = "na.learn",
+  importance                = "none",           # VI handled in a separate lighter fit
+  save.memory               = TRUE,
+  verbose                   = TRUE,
+  seed                      = 132564
+)
 
 message("Final model fit finished.", Sys.time())
+write_rds(final_ranger_fit, file=here("results","ranger",final_fit_file_name))
+
+rm(train_baked)
+gc()
+# Augment by hand. Since final_ranger_fit is a ranger object, not a workflow, I have to 
+# predict by hand and then bind into the original data
+data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+
+train_data <- training(data_split)
+calibration_data <- validation(data_split)
 
 
-#prediction using the training data 
-train_preds <- augment(final_fit, new_data = train_data)
+train_preds<-predict_byhand(new_data=train_data,
+                            prepped_recipe = prepped_recipe,
+                            ranger_fitted_model  = final_ranger_fit)
 
-# print out the metrics
+#get the hard class prediction by picking the largest value
+class <- colnames(train_preds)[max.col(train_preds, ties.method = "first")]
+class<-as_tibble(class) %>%
+  rename(.pred_class=value)
+
+# Rename and bind columns
+train_preds<-train_preds %>%
+  rename_with(~ paste0(".pred_", .))
+
+train_preds<-bind_cols(train_preds,train_data)
 
 
-train_metrics <- bind_rows(
-  roc_auc(train_preds, truth = market_desc, 
-          starts_with(".pred_")
-  ),
+train_preds<-train_preds%>%
+  mutate(weighting=hardhat::frequency_weights(lndlb)) 
+
+
+# compute training metrics with yardstick
+train_metrics <-  bind_rows(
+  roc_auc(train_preds, truth = market_desc,
+          starts_with(".pred_"),
+          case_weights = weighting),
   mn_log_loss(train_preds, truth = market_desc,
-              starts_with(".pred_")
-  ),
+              starts_with(".pred_"),
+              case_weights = weighting),
   brier_class(train_preds, truth = market_desc,
-              starts_with(".pred_")
-  )
-  
+              starts_with(".pred_"),
+              case_weights = weighting)
 )
 
 message("Fit metrics on the training data:")
 train_metrics
-
 message("End Fit metrics")
 
+train_preds<-bind_cols(class,train_preds)
 
+################################################################################
 # calibration predictions
-data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+ 
+# prediction using the validation data, bake with the prepped recipe
+#prepped_recipe<-read_rds(file=here("results","ranger",prepped_recipe_file_name))
 
-calibration_data <- validation(data_split)
-rm(data_split)
 
-#prediction using the validation data 
-calib_preds <- augment(final_fit, new_data = calibration_baked)
+calib_preds<-predict_byhand(new_data=calibration_data,
+                            prepped_recipe = prepped_recipe,
+                            ranger_fitted_model  = final_ranger_fit)
+
+
+
+#get the hard class prediction
+calib_class <- colnames(calib_preds)[max.col(calib_preds, ties.method = "first")]
+calib_class<-as.tibble(calib_class) %>%
+  rename(.pred_class=value)
+
+
+calib_preds<-calib_preds %>%
+  rename_with(~ paste0(".pred_", .))
+
+calib_preds<-bind_cols(calib_preds,calibration_data)
+
 
 # print out the metrics
 
 calib_preds <- calib_preds %>%
-  mutate(weighting=hardhat::frequency_weights(lndlb)) %>%
-  select(-.pred_class)
+  mutate(weighting=hardhat::frequency_weights(lndlb)) 
 
 calib_test_metrics <- bind_rows(
-  roc_auc(calib_preds, truth = market_desc, 
+  roc_auc(calib_preds, truth = market_desc,
           starts_with(".pred_"),
           case_weights = weighting),
   mn_log_loss(calib_preds, truth = market_desc,
@@ -299,18 +373,25 @@ calib_test_metrics <- bind_rows(
   brier_class(calib_preds, truth = market_desc,
               starts_with(".pred_"),
               case_weights = weighting)
-  
+
 )
 
 message("Fit metrics on the calibration data")
-test_metrics
+calib_test_metrics
 
 message("End Fit metrics")
 
+# Save the calibration dataset 
+
+calib_preds<-bind_cols(calib_class,calib_preds)
+
+write_rds(calib_preds, file=here("results","ranger",calib_dataset_name))
 
 
-final_fit_slim <- butcher(final_fit)
-write_rds(final_fit_slim, file=here("results","ranger",final_fit_file_name))
+message("End Training of Random Forest")
+message("Next steps: Fit the variable importance model")
+message("Next steps: Run the calibration routine.")
+
 
 
 
@@ -367,5 +448,4 @@ cat("All done")
 end_time<-Sys.time()
 end_time
 
-end_time-start_time
 sessionInfo()

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -23,7 +23,7 @@ library("glue")
 
 # load tidyverse and related
 library("tidymodels")
-
+library("butcher")
 # load machine learning and estimation tools
 # ranger imports RcppEigen and Rcpp, all 3 need to be compiled on unix.
 # you might want to install Rcpp, then RcppEigen, then ranger
@@ -151,14 +151,15 @@ best_param_file_name<-glue("{best_param_pattern}{tuning_vintage}.Rds")
 final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
 vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
 
+
 data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+
 train_data <- training(data_split)
-test_data <- testing(data_split)
 validation_data <- validation(data_split)
 rm(data_split)
 
 nrow(train_data)
-nrow(test_data)
+
 nrow(validation_data)
 
 train_raw_rows<-nrow(train_data)
@@ -211,7 +212,7 @@ selected_params<-tm[2,] %>%
 # Use update to change trees, 
 # finalize the model with best_params
 final_spec <- tune_spec %>%
-  update(trees=500)%>%
+  update(trees=20)%>%
   finalize_model(selected_params)
 
 # I have to adjust the arguments this way or I have to rewrite the entire workflow
@@ -238,35 +239,69 @@ final_fit <-
   fit(train_data)
 
 message("Final model fit finished.", Sys.time())
-#rm(final_model_spec)
-gc()
-write_rds(final_fit, file=here("results","ranger",final_fit_file_name))
 
-#prediction using the validation data 
-test_preds <- augment(final_fit, new_data = test_data)
+
+#prediction using the training data 
+train_preds <- augment(final_fit, new_data = train_data)
 
 # print out the metrics
 
-test_preds <- test_preds %>%
+
+train_metrics <- bind_rows(
+  roc_auc(calib_preds, truth = market_desc, 
+          starts_with(".pred_")
+  ),
+  mn_log_loss(calib_preds, truth = market_desc,
+              starts_with(".pred_")
+  ),
+  brier_class(calib_preds, truth = market_desc,
+              starts_with(".pred_")
+  )
+  
+)
+
+message("Fit metrics on the training data:")
+train_metrics
+
+message("End Fit metrics")
+
+
+
+
+
+#prediction using the validation data 
+calib_preds <- augment(final_fit, new_data = calibration_data)
+
+# print out the metrics
+
+calib_preds <- calib_preds %>%
   mutate(weighting=hardhat::frequency_weights(lndlb)) %>%
   select(-.pred_class)
 
-test_metrics <- bind_rows(
-  roc_auc(test_preds, truth = market_desc, 
+calib_test_metrics <- bind_rows(
+  roc_auc(calib_preds, truth = market_desc, 
           starts_with(".pred_"),
           case_weights = weighting),
-  mn_log_loss(test_preds, truth = market_desc,
+  mn_log_loss(calib_preds, truth = market_desc,
               starts_with(".pred_"),
               case_weights = weighting),
-  brier_class(test_preds, truth = market_desc,
+  brier_class(calib_preds, truth = market_desc,
               starts_with(".pred_"),
               case_weights = weighting)
   
 )
 
-message("Fit metrics")
+message("Fit metrics on the calibration data")
 test_metrics
+
 message("End Fit metrics")
+
+
+
+final_fit_slim <- butcher(final_fit)
+write_rds(final_fit_slim, file=here("results","ranger",final_fit_file_name))
+
+
 
 
 ########################################################################################################

--- a/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/train_randomforest_nocluster.R
@@ -278,7 +278,7 @@ final_ranger_fit <- ranger(
   respect.unordered.factors = "order",
   na.action                 = "na.learn",
   importance                = "none",           # VI handled in a separate lighter fit
-  save.memory               = TRUE,
+  save.memory               = FALSE,
   verbose                   = TRUE,
   seed                      = 132564
 )

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -207,7 +207,7 @@ selected_params<-tm[2,] %>%
 # Use update to change trees, 
 # finalize the model with best_params
 vi_spec <- tune_spec %>%
-  update(trees=20)%>%
+  update(trees=500)%>%
   finalize_model(selected_params)
 
 # I have to adjust the arguments this way or I have to rewrite the entire workflow

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -240,7 +240,9 @@ train_expanded<-train_data %>%
   uncount(lndlb2)
 
 
-train_expand_rows<-nrow(train_data)
+train_raw_rows<-nrow(train_data)
+train_expand_rows<-nrow(train_expanded)
+
 message("Original training dataset :", train_raw_rows )
 message("Training dataset rows (expanded):", train_expand_rows )
 

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -64,6 +64,7 @@ search_type<-"Advanced"
 
 
 source(here("R_code","analysis","helpers","modeltype_patterns.R"))
+source(here("R_code","analysis","helpers","predict_byhand.R"))
 
 
 # Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
@@ -108,7 +109,6 @@ if (runClass %in% c('Local', 'Windows')){
 }
 lbs_per_mt<-2204.62
 
-lbs_per_mt<-2204.62
 #############################################################################
 my_images<-here("images")
 descriptive_images<-here("images","descriptive")
@@ -151,7 +151,24 @@ best_param_file_name<-glue("{best_param_pattern}{tuning_vintage}.Rds")
 
 final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
 vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
+prepped_recipe_file_name<-glue("{prepped_recipe}{tuning_vintage}.Rds")
 
+#tune_res<-read_rds(file=here("results","ranger", tune_file_name))
+best_params<-read_rds(file=here("results","ranger", best_param_file_name))
+
+
+
+
+fold_results<-read_rds(file=here("results","ranger", glue("tuning_metrics_by_fold{tuning_vintage}.Rds")))
+tm<-fold_results  %>%
+  filter(.metric == "brier_class") %>%
+  group_by(mtry, min_n, .config) %>%
+  summarise(mt=mean(.estimate), .groups="drop_last")%>%
+  arrange(mt)
+
+selected_params<-tm[2,] %>%
+  select(-mt)
+rm(fold_results)
 data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
 train_data <- training(data_split)
 rm(data_split)
@@ -159,13 +176,15 @@ rm(data_split)
 nrow(train_data)
 train_raw_rows<-nrow(train_data)
 
+ train_data$rand<-runif(nrow(train_data))
+ train_data<-train_data %>%
+  dplyr::filter(rand<=.05)%>%
+  select(-rand)
 
 #expand by landed pounds 
 #replacing "in place" so that there's no chance the recipe fits to the wrong data.
 train_data<-train_data %>%
-  select(-c(price,priceR_CPI, dlrid, myl_id)) %>%
-  mutate(lndlb2=lndlb) %>%
-  uncount(lndlb2)
+  select(-c(price,priceR_CPI, dlrid, myl_id)) 
 
 train_expand_rows<-nrow(train_data)
 
@@ -179,78 +198,94 @@ message("Training dataset rows (expanded):", train_expand_rows )
 # 
 # The recipe simply defines the dataset, outcome (reponse, y) variable, id variables,
 # and predictor variables.
-source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
+# source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
+# I need to handle the prep and bake the recipe manually, instead of using a workflow.
 
+# read in the prepped recipe
+prepped_recipe<-read_rds(file=here("results","ranger",prepped_recipe_file_name))
+				
 # Set up the tuning workflow
-source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
+# source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
 
-# Read in best parameters.  Do a training on the full training dataset
+# configure the final_spec
+vi_spec <- rand_forest(
+  trees = 500,
+  mtry = tune(),
+  min_n = tune(),
+) %>%
+  set_mode("classification") %>%
+  set_engine("ranger",
+             num.threads=!!my.ranger.sequential.threads, 
+             na.action="na.learn", 
+             respect.unordered.factors="order",
+             importance="impurity_corrected", # Impurity corrected
+             oob.error = FALSE, # not used.
+             keep.inbag=FALSE, # default, but explicit 
+             probability = TRUE, # set to a probability model
+             write.forest=FALSE,
+             save.memory=FALSE,
+             verbose=TRUE,  # default, but explicit 
+             seed= 132564) %>% 
+  finalize_model(selected_params) 
 
-#tune_res<-read_rds(file=here("results","ranger", tune_file_name))
-best_params<-read_rds(file=here("results","ranger", best_param_file_name))
-
-fold_results<-read_rds(file=here("results","ranger", glue("tuning_metrics_by_fold{tuning_vintage}.Rds")))
-tm<-fold_results  %>%
-  filter(.metric == "brier_class") %>%
-  group_by(mtry, min_n, .config) %>%
-  summarise(mt=mean(.estimate), .groups="drop_last")%>%
-  arrange(mt)
-
-selected_params<-tm[2,] %>%
-  select(-mt)
-
-
-
-
-############################################
-# Final fit spec
-# Use update to change trees, 
-# finalize the model with best_params
-vi_spec <- tune_spec %>%
-  update(trees=500)%>%
-  finalize_model(selected_params)
-
-# I have to adjust the arguments this way or I have to rewrite the entire workflow
-# Verbose=TRUE to monitor what is going on.
-# save.memory slows it way down, but writes trees to disk to save on memory. I think I can comment out
-vi_spec$eng_args$verbose<-rlang::quo(TRUE)
-#vi_spec$eng_args$save.memory<-rlang::quo(TRUE)
-vi_spec$eng_args$importance<-rlang::quo("impurity_corrected")
-vi_spec$eng_args$write.forest<-rlang::quo(FALSE)
+translate(vi_spec)
+				  
+#Not currently used for training, but keeping it around
+class_and_probs_metrics <- metric_set(brier_class,mn_log_loss, roc_auc)
 
 
+#expand by landed pounds 
+train_expanded<-train_data %>% 
+  mutate(lndlb2=lndlb) %>%
+  uncount(lndlb2)
 
 
-# finalize model by setting best model hyperparameters
-vi_wf  <- BSB.Ranger.tuning.Workflow %>%
-  update_model(vi_spec)
-set.seed(132564)
+train_expand_rows<-nrow(train_data)
+message("Original training dataset :", train_raw_rows )
+message("Training dataset rows (expanded):", train_expand_rows )
 
-# clean up
-rm(BSB.Ranger.tuning.Workflow)
-gc()
+# Apply 
+train_baked <- bake(
+  prepped_recipe,
+  new_data = train_expanded)
 
-fit_control<-control_parsnip(verbosity = 2L, catch = FALSE)
 
-# set.seed(132564)
-# 
-# Final model fitting on the full training dataset to estimate importance
-message("Fitting model to estimate variable importance.", Sys.time())
-vi_fit <-
-  vi_wf %>%
-  fit(train_data)
 
-vi_fit_slim <- butcher(vi_fit)
-rm(vi_fit)
+# Final model fitting on the baked dataset
+message("Fitting final model:...")
+vi_ranger_fit <- ranger(
+  market_desc ~ .,                              # outcome ~ all remaining columns
+  data                      = train_baked,
+  num.trees                 = 500,              # full 500 trees (memory budget allows)
+  mtry                      = selected_params$mtry,
+  min.node.size             = selected_params$min_n,
+  probability               = TRUE,            # required: returns class probabilities
+  num.threads              =  my.ranger.sequential.threads, 
+  respect.unordered.factors = "order",
+  na.action                 = "na.learn",
+  importance                = "impurity_corrected",           # VI handled here
+  save.memory               = FALSE,
+  write.forest              = FALSE,  # don't need to write forest. saves memory
+  verbose                   = TRUE,
+  seed                      = 132564
+)
+
+message("Final model fit finished.", Sys.time())
+write_rds(vi_ranger_fit, file=here("results","ranger",vi_file_name))
 gc()
 
 message("Variable Importance Model fit finished", Sys.time())
 # 
 # 
 # Pull the variable importance
- vi_data<-vi_fit_slim%>%
-   extract_fit_parsnip() %>%
-   vi(method = "model") 
+ vi_data<- vi_ranger_fit$variable.importance
+ 
+ vi_data <- tibble(
+   Variable   = names(vi_data),
+   Importance = vi_data
+ ) %>%
+   arrange(desc(Importance))
+ 
 # 
 write_rds(vi_data, file=here("results","ranger",vi_file_name))
 message("Variable Importance metrics saved", Sys.time())
@@ -284,6 +319,7 @@ vi_data <- vi_data %>%
                                    "Dealer Propensity Medium" = "LagSharePoundsMedium",
                                    "Dealer Propensity Large" = "LagSharePoundsLarge",
                                    "Dealer Propensity Jumbo" = "LagSharePoundsJumbo",
+                                   "Trip BSB Landings" = "trip_level_BSB",
                                    "Year" = "year",
                                    "Stockarea Catch Jumbo" = "MA7_StockareaQJumbo",
                                    "Stockarea Catch Large" = "MA7_StockareaQLarge",
@@ -309,7 +345,7 @@ p_vip <- ggplot(vi_data %>% slice_max(Importance, n=20), aes(x = Importance, y =
   geom_col(fill = "#1B6CA8", width = 0.7) +
   geom_vline(xintercept = 0, colour = "grey20", linewidth = 0.3) +
   scale_x_continuous(
-    name   = "Mean Decrease Impurity (Corrected)",
+    name   = "Mean Decrease in (Corrected) Impurity ",
     expand = expansion(mult = c(0, 0.05))
   ) +
   scale_y_discrete(name = NULL) +
@@ -341,7 +377,7 @@ p_vip <- ggplot(vi_data,  aes(x = Importance, y = Variable)) +
   geom_col(fill = "#1B6CA8", width = 0.7) +
   geom_vline(xintercept = 0, colour = "grey20", linewidth = 0.3) +
   scale_x_continuous(
-    name   = "Mean Decrease Impurity (Corrected)",
+    name   = "Mean Decrease in (Corrected) Impurity ",
     expand = expansion(mult = c(0, 0.05))
   ) +
   scale_y_discrete(name = NULL) +

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -1,0 +1,268 @@
+###############################################################################
+# Purpose: 	Train the RF with the impurity_correction option to get VI metrics.   
+# on DLRID for the validation. Unclassified are excluded.
+# this assumes you have already trined a model using 
+# tune_randomforest_nocluster.R
+
+# Inputs:
+#  - data_split (from tune_randomforest_nocluster.R)
+#  - BSB.Classification.Recipe.R
+#  - BSB.Workflow.Setup.R
+
+# Outputs:
+#  - final_fit results
+#  - variable importance
+###############################################################################  
+
+library("here")
+
+# load tidyverse and related
+library("tidyverse")
+library("scales")
+library("glue")
+
+# load tidyverse and related
+library("tidymodels")
+
+# load machine learning and estimation tools
+# ranger imports RcppEigen and Rcpp, all 3 need to be compiled on unix.
+# you might want to install Rcpp, then RcppEigen, then ranger
+
+library("nnet")
+library("ranger")
+
+library("partykit")
+library("bonsai")
+# load utilities
+library("knitr")
+library("kableExtra")
+library("viridis")
+library("vip")
+library("conflicted")
+
+#deal with conflicts
+conflicts_prefer(dplyr::filter())
+conflicts_prefer(dplyr::lag())
+conflicts_prefer(purrr::discard())
+conflicts_prefer(dplyr::group_rows())
+conflicts_prefer(yardstick::spec())
+conflicts_prefer(recipes::fixed())
+conflicts_prefer(recipes::step())
+conflicts_prefer(viridis::viridis_pal())
+conflicts_prefer(vip::vi)
+here::i_am("R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R")
+
+# Set these two to control the size of the dataset. Useful for making sure code 
+# works.
+#Set up model type
+modeltype<-"nocluster"
+# OR "nocluster", or "fiveclass", or "noc5class" OR "standard"
+
+search_type<-"Advanced"
+# search_type in "Initial", "Prototype","Advanced")
+
+
+source(here("R_code","analysis","helpers","modeltype_patterns.R"))
+
+
+# Only used with search_type<-"Prototype" -- how much data do you want in the dataset to prototype the code
+testing_fraction<-1			  
+start_time<-Sys.time()
+
+#Turn bayesian tuning on or off.
+bayes_tune<-"FALSE"
+
+# Determine what platform the code is running on and set the number of threads for ranger
+platform <- Sys.info()['sysname']
+# check the name of the effective_user
+if(platform == 'Linux'){
+  if (grep("PREEMPT_DYNAMIC",Sys.info()['version'])==1){
+    runClass<-'DynamicContainer'
+  } else{ 
+    runClass <- 'Container'
+  }
+}
+
+
+if(platform == 'Windows'){
+  runClass<-'Windows'
+}
+
+if (runClass %in% c('Local', 'Windows')){
+  my.parallel.threads<-1
+  my.ranger.multi.threads<-5
+} else if (runClass %in% c('Container','DynamicContainer')){ 
+  
+  # on the container, you're allocated 24 threads	and 90 (or 96gb of memory)
+  # Because the dataset is big, you are much better off doing 2 and 11 (or 1 and 22)
+  my.ranger.sequential.threads<-24
+  
+  # Kill background logger if it is on
+  system("pkill -f 'while true.*top'", ignore.stdout = TRUE, ignore.stderr = TRUE)
+  message("CPU logger stopped")
+  
+  # start background logger
+  source(here("R_code","analysis","helpers","background_logger.R"))
+  
+}
+lbs_per_mt<-2204.62
+
+lbs_per_mt<-2204.62
+#############################################################################
+my_images<-here("images")
+descriptive_images<-here("images","descriptive")
+exploratory_images<-here("images","exploratory")
+
+#############################################################################
+# Read in data and tuning results.
+#############################################################################
+
+# data vintage
+vintage_string<-list.files(here("data_folder","main","commercial"), pattern=glob2rx("BSB_estimation_dataset*Rds"))
+vintage_string<-gsub("BSB_estimation_dataset","",vintage_string)
+vintage_string<-gsub(".Rds","",vintage_string)
+data_vintage<-max(vintage_string)
+
+
+
+
+
+#data_vintage<-as.character(Sys.Date())
+################################################################################
+# Read in data and tuning results.
+################################################################################
+
+
+# Pick up the most recent tuning
+tuning_vintage<-list.files(here("results","ranger"), pattern=glob2rx(glue("{tuning_pattern}*.Rds")))
+tuning_vintage<-gsub(tuning_pattern,"",tuning_vintage)
+tuning_vintage<-gsub(".Rds","",tuning_vintage)
+tuning_vintage<-max(tuning_vintage)
+
+# Assemble file names to read in data, tuning results, and best_params.
+# Although the source data has a different vintage, I'm loading in "data_split" which has the same vintage as the tuning
+# The tuning and best_param already exist.
+# the final fit and vi files will be created by this file. I'm choosing to use 
+# the tuning date here, since the final fit and tuning go together.
+data_save_name<-glue("{data_pattern}{tuning_vintage}.Rds")
+tune_file_name<-glue("{tuning_pattern}{tuning_vintage}.Rds")
+best_param_file_name<-glue("{best_param_pattern}{tuning_vintage}.Rds")
+
+final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
+vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
+
+data_split<-readr::read_rds(file=here("results","ranger",data_save_name))
+train_data <- training(data_split)
+rm(data_split)
+
+nrow(train_data)
+train_raw_rows<-nrow(train_data)
+
+
+#expand by landed pounds 
+#replacing "in place" so that there's no chance the recipe fits to the wrong data.
+train_data<-train_data %>%
+  select(-c(price,priceR_CPI, dlrid, myl_id)) %>%
+  mutate(lndlb2=lndlb) %>%
+  uncount(lndlb2)
+
+train_expand_rows<-nrow(train_data)
+
+
+
+message("Original training dataset :", train_raw_rows )
+message("Training dataset rows (expanded):", train_expand_rows )
+
+
+# # Recipe definition
+# 
+# The recipe simply defines the dataset, outcome (reponse, y) variable, id variables,
+# and predictor variables.
+source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
+
+# Set up the tuning workflow
+source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
+
+# Read in best parameters.  Do a training on the full training dataset, predict on the validation dataset. Save the data
+
+#tune_res<-read_rds(file=here("results","ranger", tune_file_name))
+best_params<-read_rds(file=here("results","ranger", best_param_file_name))
+
+fold_results<-read_rds(file=here("results","ranger", glue("tuning_metrics_by_fold{tuning_vintage}.Rds")))
+tm<-fold_results  %>%
+  filter(.metric == "brier_class") %>%
+  group_by(mtry, min_n, .config) %>%
+  summarise(mt=mean(.estimate), .groups="drop_last")%>%
+  arrange(mt)
+
+selected_params<-tm[2,] %>%
+  select(-mt)
+
+
+
+
+############################################
+# Final fit spec
+# Use update to change trees, 
+# finalize the model with best_params
+vi_spec <- tune_spec %>%
+  update(trees=500)%>%
+  finalize_model(selected_params)
+
+# I have to adjust the arguments this way or I have to rewrite the entire workflow
+# Verbose=TRUE to monitor what is going on.
+# save.memory slows it way down, but writes trees to disk to save on memory. I think I can comment out
+vi_spec$eng_args$verbose<-rlang::quo(TRUE)
+#vi_spec$eng_args$save.memory<-rlang::quo(TRUE)
+vi_spec$eng_args$importance<-rlang::quo("impurity_corrected")
+vi_spec$eng_args$write.forest<-rlang::quo(FALSE)
+
+
+
+
+# finalize model by setting best model hyperparameters
+vi_wf  <- BSB.Ranger.tuning.Workflow %>%
+  update_model(vi_spec)
+set.seed(132564)
+
+# clean up
+rm(BSB.Ranger.tuning.Workflow)
+gc()
+
+fit_control<-control_parsnip(verbosity = 2L, catch = FALSE)
+
+# set.seed(132564)
+# 
+# Final model fitting on the full training dataset to estimate importance
+message("Fitting model to estimate variable importance.", Sys.time())
+vi_fit <-
+  vi_wf %>%
+  fit(train_data)
+
+message("Variable Importance Model fit finished", Sys.time())
+# 
+# 
+# Pull the variable importance
+ vi_data<-vi_fit%>%
+   extract_fit_parsnip() %>%
+   vi(method = "model") 
+# 
+# write_rds(vi_data, file=here("results","ranger",vi_file_name))
+# message("Variable Importance metrics saved", Sys.time())
+
+########################################################################################################
+########################################################################################################
+
+
+
+system("pkill -f 'while true.*top'", ignore.stdout = TRUE, ignore.stderr = TRUE)
+message("CPU logger stopped")
+
+cat("All done")
+
+
+end_time<-Sys.time()
+end_time
+
+end_time-start_time
+sessionInfo()

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -23,6 +23,7 @@ library("glue")
 
 # load tidyverse and related
 library("tidymodels")
+library("butcher")
 
 # load machine learning and estimation tools
 # ranger imports RcppEigen and Rcpp, all 3 need to be compiled on unix.
@@ -206,7 +207,7 @@ selected_params<-tm[2,] %>%
 # Use update to change trees, 
 # finalize the model with best_params
 vi_spec <- tune_spec %>%
-  update(trees=500)%>%
+  update(trees=20)%>%
   finalize_model(selected_params)
 
 # I have to adjust the arguments this way or I have to rewrite the entire workflow
@@ -239,16 +240,20 @@ vi_fit <-
   vi_wf %>%
   fit(train_data)
 
+vi_fit_slim <- butcher(vi_fit)
+rm(vi_fit)
+gc()
+
 message("Variable Importance Model fit finished", Sys.time())
 # 
 # 
 # Pull the variable importance
- vi_data<-vi_fit%>%
+ vi_data<-vi_fit_slim%>%
    extract_fit_parsnip() %>%
    vi(method = "model") 
 # 
-# write_rds(vi_data, file=here("results","ranger",vi_file_name))
-# message("Variable Importance metrics saved", Sys.time())
+write_rds(vi_data, file=here("results","ranger",vi_file_name))
+message("Variable Importance metrics saved", Sys.time())
 
 ########################################################################################################
 ########################################################################################################
@@ -257,6 +262,113 @@ message("Variable Importance Model fit finished", Sys.time())
 
 system("pkill -f 'while true.*top'", ignore.stdout = TRUE, ignore.stderr = TRUE)
 message("CPU logger stopped")
+
+
+
+
+
+# PLOT
+
+
+
+
+vi_data <- vi_data %>%
+  #slice_max(Importance, n = 20) %>% # top 20 only at single-column width
+  mutate(
+    Variable = forcats::fct_reorder(Variable, Importance),
+    Variable = forcats::fct_recode(Variable,
+                                   "Price Difference Jumbo" = "Price_Diff_J",
+                                   "Price Difference Large" = "Price_Diff_L",
+                                   "Price Difference Medium" = "Price_Diff_M",
+                                   "Dealer Propensity Small" = "LagSharePoundsSmall",
+                                   "Dealer Propensity Medium" = "LagSharePoundsMedium",
+                                   "Dealer Propensity Large" = "LagSharePoundsLarge",
+                                   "Dealer Propensity Jumbo" = "LagSharePoundsJumbo",
+                                   "Year" = "year",
+                                   "Stockarea Catch Jumbo" = "MA7_StockareaQJumbo",
+                                   "Stockarea Catch Large" = "MA7_StockareaQLarge",
+                                   "Stockarea Catch Medium" = "MA7_StockareaQMedium",
+                                   "Stockarea Catch Small" = "MA7_StockareaQSmall",
+                                   "State Catch Jumbo" = "MA7_StateQJumbo",
+                                   "State Catch Large" = "MA7_StateQLarge",
+                                   "State Catch Medium" = "MA7_StateQMedium",
+                                   "State Catch Small" = "MA7_StateQSmall",
+                                   "Gear Catch Jumbo" = "MA7_gearQJumbo",
+                                   "Gear Catch Large" = "MA7_gearQLarge",
+                                   "Gear Catch Medium" = "MA7_gearQMedium",
+                                   "Gear Catch Small" = "MA7_gearQSmall",
+                                   "Transaction Weight" = "lndlb",
+                                   "Stockarea Trips" = "MA7_stockarea_trips",
+                                   "State Trips" = "MA7_state_trips"
+    )
+  )
+
+
+
+p_vip <- ggplot(vi_data %>% slice_max(Importance, n=20), aes(x = Importance, y = Variable)) +
+  geom_col(fill = "#1B6CA8", width = 0.7) +
+  geom_vline(xintercept = 0, colour = "grey20", linewidth = 0.3) +
+  scale_x_continuous(
+    name   = "Mean Decrease Impurity (Corrected)",
+    expand = expansion(mult = c(0, 0.05))
+  ) +
+  scale_y_discrete(name = NULL) +
+  theme_bw(base_size = 9) +
+  theme(
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor   = element_blank(),
+    panel.grid.major.x = element_line(colour = "grey88", linewidth = 0.3),
+    axis.text.y        = element_text(size = 7, colour = "grey20"),
+    axis.text.x        = element_text(size = 7, colour = "grey20"),
+    axis.title.x       = element_text(size = 8),
+    plot.margin        = margin(4, 6, 4, 4, "pt")
+  )
+p_vip
+# --- 3. Save at ICES JMS single-column specification ---
+ggsave(
+  here("results", "ranger", "final",
+       glue("vip{modeltype}{tuning_vintage}.pdf")),
+  plot   = p_vip,
+  width  = 84,
+  height = 110,    # 20 bars fit cleanly; adjust in 5mm increments if needed
+  units  = "mm",
+  device = cairo_pdf
+)
+
+
+
+p_vip <- ggplot(vi_data,  aes(x = Importance, y = Variable)) +
+  geom_col(fill = "#1B6CA8", width = 0.7) +
+  geom_vline(xintercept = 0, colour = "grey20", linewidth = 0.3) +
+  scale_x_continuous(
+    name   = "Mean Decrease Impurity (Corrected)",
+    expand = expansion(mult = c(0, 0.05))
+  ) +
+  scale_y_discrete(name = NULL) +
+  theme_bw(base_size = 9) +
+  theme(
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor   = element_blank(),
+    panel.grid.major.x = element_line(colour = "grey88", linewidth = 0.3),
+    axis.text.y        = element_text(size = 7, colour = "grey20"),
+    axis.text.x        = element_text(size = 7, colour = "grey20"),
+    axis.title.x       = element_text(size = 8),
+    plot.margin        = margin(4, 6, 4, 4, "pt")
+  )
+
+# --- 3. Save at ICES JMS single-column specification ---
+ggsave(
+  here("results", "ranger", "final",
+       glue("vipFULL{modeltype}{tuning_vintage}.pdf")),
+  plot   = p_vip,
+  width  = 84,
+  height = 110,    # 20 bars fit cleanly; adjust in 5mm increments if needed
+  units  = "mm",
+  device = cairo_pdf
+)
+
+
+
 
 cat("All done")
 

--- a/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
+++ b/R_code/analysis/fit_random_forest/variable_importance_randomforest_nocluster.R
@@ -184,7 +184,7 @@ source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R
 # Set up the tuning workflow
 source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
 
-# Read in best parameters.  Do a training on the full training dataset, predict on the validation dataset. Save the data
+# Read in best parameters.  Do a training on the full training dataset
 
 #tune_res<-read_rds(file=here("results","ranger", tune_file_name))
 best_params<-read_rds(file=here("results","ranger", best_param_file_name))

--- a/R_code/analysis/helpers/modeltype_patterns.R
+++ b/R_code/analysis/helpers/modeltype_patterns.R
@@ -12,7 +12,8 @@ if (modeltype=="standard"){
   final_pattern<-"BSB_ranger_results"
   vi_pattern<-glue("BSB_ranger_VI")
   best_param_pattern<-glue("BSB_ranger_best_params")
-  
+  prepped_recipe<-glue("BSB_ranger_prepped_recipe")
+  calib_data_pattern<-glue("BSB_ranger_calib_preds")
   
 } else if (modeltype=="nocluster"){
   data_pattern<-"nocluster_data_split"
@@ -20,6 +21,10 @@ if (modeltype=="standard"){
   final_pattern<-"BSB_ranger_nocluster_results"
   vi_pattern<-glue("BSB_ranger_nocluster_VI")
   best_param_pattern<-glue("BSB_ranger_nocluster_best_params")
+  prepped_recipe<-glue("BSB_ranger_nocluster_prepped_recipe")
+  calib_data_pattern<-glue("BSB_ranger_nocluster_calib_preds")
+  
+  
   
 } else if (modeltype=="TESTnocluster"){
   data_pattern<-"TEST_nocluster_data_split"
@@ -27,6 +32,10 @@ if (modeltype=="standard"){
   final_pattern<-"TEST_BSB_ranger_nocluster_results"
   vi_pattern<-"TEST_BSB_ranger_nocluster_VI"
   best_param_pattern<-glue("TEST_BSB_ranger_nocluster_best_params")
+  prepped_recipe<-glue("TEST_BSB_ranger_nocluster_prepped_recipe")
+  calib_data_pattern<-glue("TEST_BSB_ranger_nocluster_calib_preds")
+  
+  
   
 }else {
   stop("Unknown modeltype")

--- a/R_code/analysis/helpers/predict_byhand.R
+++ b/R_code/analysis/helpers/predict_byhand.R
@@ -1,0 +1,35 @@
+
+# =============================================================================
+# PREDICTION WRAPPER
+#
+# This function enforces the bake → predict sequence programmatically.
+# It is the safety equivalent of a fitted workflow's predict() method:
+# you cannot call the model without preprocessing because the preprocessing
+# is inside the function.
+#
+# Usage (fresh session or production):
+#   preds <- predict_market(unclassified_data)
+#
+# Arguments:
+#   new_data     — raw data frame in the same format as the training data
+#                  (unexpanded; must contain all predictor columns)
+#   prepped_recipe  — the prepped_recipe
+#   ranger_fitted_model   — the output of a ranger fit
+#
+# Returns a tibble with columns .pred_CCCCCCCC,
+# one row per row of new_data.
+# =============================================================================
+predict_byhand <- function(new_data=train_data,
+                           prepped_recipe = prepped_recipe,
+                           ranger_fitted_model  = final_ranger_fit) {
+  
+  # ranger sees the data — step_novel() ensures unseen factor levels are pooled
+  # to "new" rather than causing an error.
+  new_baked <- bake(prepped_recipe, new_data = new_data)
+  
+  # -- Predict: return class probabilities -------------------------------------
+  predict(ranger_fitted_model, data = new_baked, type = "response")$predictions %>%
+    as_tibble() %>%
+    rename_with(~ paste0(".pred_", .))
+}
+

--- a/writing/Economic_informed_stock_assessments.Rmd
+++ b/writing/Economic_informed_stock_assessments.Rmd
@@ -48,7 +48,7 @@ R_code/data_extraction_processing/processing/commercial\00_commercial_processing
 
 The RF model was tuned with tune_random_forest_nocluster.R
 The RF model was trained with tune_random_forest_nocluster.R
-Variable importance metrics produced by variable_importance_random_forest_nocluster.R
+Variable importance metrics and figures produced by variable_importance_random_forest_nocluster.R
 
 The model is calibrated with "calibration and validation.Rmd"
 
@@ -60,7 +60,6 @@ Hedonic model was fit with "bsb_size_classifications.do". This file also generat
 * figure2 (windows only)
 * predictions_heatmap
 * out_of_sample_predictions.Rmd makes out of sample predictions.
-* calibration_and_validation - VIP
 
 renders on windows, but not on my container (missing endnotes.sty from that tex install)
 

--- a/writing/Economic_informed_stock_assessments.Rmd
+++ b/writing/Economic_informed_stock_assessments.Rmd
@@ -41,11 +41,16 @@ output:
  <!---- 
 Summary and Housekeeping
 
-I did my data processing with  ``\stata_code\data_extraction_processing\extraction\commercial\00_cams_extraction.do`` and ``00_extraction_wrapper.do``
-And a final round of data processing with data_prep_ml.R (run 3/13)
+Data extraction is handled in the "DataPull" repository. 
+Data processing was ported to R and handled with 
 
-The RF model was fit with "estimate_randomforest_nocluster.R", which has a few dependencies, mostly for the recipe and workflow.
-The model is finalized with final_fit and calibrated with "calibration and validation.Rmd"
+R_code/data_extraction_processing/processing/commercial\00_commercial_processing_wrapper.R
+
+The RF model was tuned with tune_random_forest_nocluster.R
+The RF model was trained with tune_random_forest_nocluster.R
+Variable importance metrics produced by variable_importance_random_forest_nocluster.R
+
+The model is calibrated with "calibration and validation.Rmd"
 
 
 Hedonic model was fit with "bsb_size_classifications.do". This file also generates summary statistics for the hedonic model, a table of coefficient results, and graphs some of the marginal effects of the factors.

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -126,6 +126,7 @@ here::i_am("writing/calibration_and_validation.Rmd")
 
 #handle model patterns
 source(here("R_code","analysis","helpers","modeltype_patterns.R"))
+source(here("R_code","analysis","helpers","predict_byhand.R"))
 
 
 
@@ -162,6 +163,12 @@ tuning_vintage<-max(tuning_vintage)
 finalfit_vintage<-tuning_vintage
 VI_vintage<-tuning_vintage
 
+
+final_fit_file_name<-glue("{final_pattern}{tuning_vintage}.Rds")
+vi_file_name<-glue("{vi_pattern}{tuning_vintage}.Rds")
+prepped_recipe_file_name<-glue("{prepped_recipe}{tuning_vintage}.Rds")
+
+
 vintage_string<-list.files(here("data_folder","main","commercial"), pattern=glob2rx("BSB_estimation_dataset*Rds"))
 
 raw_oos_data_vintage_string<-list.files(here("data_folder","main","commercial"), pattern=glob2rx("BSB_unclassified_dataset*Rds"))
@@ -192,31 +199,47 @@ validation_data<-validation_data %>%
 test_data<-test_data %>%
   mutate(weighting=frequency_weights(lndlb))
 
-rm(data_split)
+prepped_recipe<-read_rds(file=here("results","ranger",prepped_recipe_file_name))
+
+final_ranger_fit<-read_rds(file=here("results","ranger",glue("{final_pattern}{tuning_vintage}.Rds")))
 
 
-final_fit<-read_rds(file=here("results","ranger",glue("{final_pattern}{tuning_vintage}.Rds")))
 
 # And the recipe
-classification_recipe<-extract_recipe(final_fit)
+#classification_recipe<-extract_recipe(final_fit)
 
 
 # here, I have to augment, probably the data_split object, but it coudl be the validation dataset.
-final_predictions <- augment(final_fit,validation_data)
 
+validation_preds<-predict_byhand(new_data=validation_data,
+                            prepped_recipe = prepped_recipe,
+                            ranger_fitted_model  = final_ranger_fit)
 
-# pull the probability names
-prob_names<-colnames(final_predictions) 
-prob_names<-grep("^\\.pred_", prob_names, value=TRUE)
-prob_names<-grep("^\\.pred_class", prob_names, value=TRUE, invert=TRUE)
+class <- colnames(validation_preds)[max.col(validation_preds, ties.method = "first")]
+class<-as_tibble(class) %>%
+  rename(.pred_class=value)
 
+# Bind cols
+validation_preds<-bind_cols(validation_preds,validation_data)
+
+validation_preds<-validation_preds%>%
+  mutate(weighting=hardhat::frequency_weights(lndlb)) 
 
 # look at the fit metrics
-# I think I have to do this by hand from final_predictions (or from the augmented training data
-#final_fit_metrics<-final_fit %>%
-#  collect_metrics()
-#final_fit_metrics
 
+# compute training metrics with yardstick
+validation_metrics <-  bind_rows(
+  roc_auc(validation_preds, truth = market_desc,
+          starts_with(".pred_"),
+          case_weights = weighting),
+  mn_log_loss(validation_preds, truth = market_desc,
+              starts_with(".pred_"),
+              case_weights = weighting),
+  brier_class(validation_preds, truth = market_desc,
+              starts_with(".pred_"),
+              case_weights = weighting)
+)
+validation_metrics
 ```
 
 Log loss of the final fit is slightly better than that of the average of the individual folds. This is normal/reasonable, since it uses more data than each of the individual folds.  It's not so different that alarm bells go off.
@@ -341,7 +364,7 @@ prob_names<-grep("^\\.pred_class", prob_names, value=TRUE, invert=TRUE)
 
 
 
-final_pr<-final_predictions %>%
+final_pr<-validation_preds %>%
   pr_curve(market_desc,  any_of(prob_names)) %>%
   autoplot()
 ggsave(here("results","ranger","final",glue("pr_curve{modeltype}{finalfit_vintage}.png")), plot=final_pr)
@@ -359,9 +382,9 @@ Use the Validation set to (1 assess how well the model fits) and 2. Calibrate if
 #The validation plots indicate characteristic issues with probability trees. All models are underconfident. Groups of observations with a 75% predicted probability of Jumbo have a true probability of Jumbo of almost 90%.  Groups of observations with a predicted probability of ~15% probabilty of Jumbo have a true probability closer to 10%.
 
 # Calibration should fix this.
-validation_data<-final_predictions
+validation_data<-validation_preds
 
-cal_gg <- validation_data %>%
+cal_gg <- validation_preds %>%
   cal_plot_windowed(
     truth          = market_desc,
     estimate       = c(.pred_Jumbo, .pred_Large, .pred_Medium, .pred_Small),

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -14,7 +14,7 @@ editor_options:
 fontsize: 12pt
 params:
   modeltype:
-    value: noclusterTEST
+    value: nocluster
     choices:
     - nocluster
     - noclusterTEST
@@ -49,7 +49,7 @@ Calibration and Validation
  
  --->
 ```{r global_options, include=FALSE}
-
+search_type<-"Advanced"
 modeltype<-params$modeltype
 
 
@@ -157,13 +157,10 @@ tuning_vintage<-gsub(tuning_pattern,"",tuning_vintage)
 tuning_vintage<-gsub(".Rds","",tuning_vintage)
 tuning_vintage<-max(tuning_vintage)
 
-# My "final fit" bombed out because I didn't have drive space.  
-# finalfit_vintage<-list.files(here("results","ranger"), pattern=glob2rx(glue("{final_pattern}*Rds")))
-# finalfit_vintage<-gsub(final_pattern,"",finalfit_vintage)
-# finalfit_vintage<-gsub(".Rds","",finalfit_vintage)
-# finalfit_vintage<-max(finalfit_vintage)
+# Tuning, training, VI code guarantees that the finalfit and VI vintages are the same as the tuning vintages.  
 
 finalfit_vintage<-tuning_vintage
+VI_vintage<-tuning_vintage
 
 vintage_string<-list.files(here("data_folder","main","commercial"), pattern=glob2rx("BSB_estimation_dataset*Rds"))
 
@@ -185,28 +182,28 @@ read in the final model, extract the recipe and the predictors, extract the pred
 # # this was created with data_prep_ml.Rmd
 data_split<-readr::read_rds(file=here("results","ranger",glue("{data_pattern}{data_vintage_string}.Rds")))
 # Onlyneed the test and validation 
-# train_data <- training(data_split)
+train_data <- training(data_split)
 validation_data <- validation(data_split)
 test_data <- testing(data_split)
+
+# recreate the frequency weights variables
+validation_data<-validation_data %>%
+  mutate(weighting=frequency_weights(lndlb))
+test_data<-test_data %>%
+  mutate(weighting=frequency_weights(lndlb))
+
 rm(data_split)
 
 
 final_fit<-read_rds(file=here("results","ranger",glue("{final_pattern}{tuning_vintage}.Rds")))
 
-
-# What is the workflow
-final_workflow<-extract_workflow(final_fit)
-
 # And the recipe
-extract_recipe(final_fit)
+classification_recipe<-extract_recipe(final_fit)
 
-preds<-final_fit$.workflow[[1]]$pre$actions$recipe$recipe$var_info %>%
- dplyr::filter(role=="predictor")
 
-num_preds<-nrow(preds)
+# here, I have to augment, probably the data_split object, but it coudl be the validation dataset.
+final_predictions <- augment(final_fit,validation_data)
 
-final_predictions<-final_fit %>%
-  collect_predictions()
 
 # pull the probability names
 prob_names<-colnames(final_predictions) 
@@ -215,9 +212,10 @@ prob_names<-grep("^\\.pred_class", prob_names, value=TRUE, invert=TRUE)
 
 
 # look at the fit metrics
-final_fit_metrics<-final_fit %>%
-  collect_metrics()
-final_fit_metrics
+# I think I have to do this by hand from final_predictions (or from the augmented training data
+#final_fit_metrics<-final_fit %>%
+#  collect_metrics()
+#final_fit_metrics
 
 ```
 
@@ -228,12 +226,11 @@ Log loss of the final fit is slightly better than that of the average of the ind
 
 Look at the VIP, ROC, and PR curves
 
-```{r VIP}
+```{r VIP, eval=FALSE}
 # Look at variable importance. I want to see all the predictors.
-# The scale is different from previous versions, because I switched the variable importance method in the Workflow/recipe to "Permutation"
+# The scale is different from previous versions, because I switched the variable importance method in the Workflow/recipe to "Impurity Corrected."
 
 vi_data<-read_rds(file=here("results","ranger",glue("{vi_pattern}{finalfit_vintage}.Rds")))
-
 
 vi_data <- vi_data %>%
   #slice_max(Importance, n = 20) %>% # top 20 only at single-column width
@@ -358,11 +355,11 @@ Use the Validation set to (1 assess how well the model fits) and 2. Calibrate if
 ```{r Validation_predictions}
 # Apply the Final fit to the validation dataset. 
 
-validation_data <- augment(final_workflow,validation_data)
 
 #The validation plots indicate characteristic issues with probability trees. All models are underconfident. Groups of observations with a 75% predicted probability of Jumbo have a true probability of Jumbo of almost 90%.  Groups of observations with a predicted probability of ~15% probabilty of Jumbo have a true probability closer to 10%.
 
 # Calibration should fix this.
+validation_data<-final_predictions
 
 cal_gg <- validation_data %>%
   cal_plot_windowed(
@@ -426,7 +423,6 @@ ggsave(
 
 
 ```
-
 
 Experiment with different methods of calibration. Beta fits a 3 parameter beta model (2 shape, 1 location), performing 4 distinct 1 vs all models and then re-normalalizing the results.  Iso fits an isotonic regression (4 separate 1 vs all again).  cal_estimate_multinom fits logistic splines and seemed to work better than the version that just fit a multinomial logistic.
 
@@ -908,7 +904,7 @@ ggsave(here("results","ranger","final",glue("validation_calibrated_UWroc_curve{m
 # Predict Out of Sample on the testing holdout.
 
 
-test_data <- augment(final_workflow,test_data)
+test_data <- augment(final_fit,test_data)
 
 ############ How well calibrated is the model? 
 # A: Better when calibrated - same pattern as training data.

--- a/writing/calibration_and_validation.Rmd
+++ b/writing/calibration_and_validation.Rmd
@@ -624,142 +624,13 @@ ggsave(here("results","ranger","final",glue("validation_uncal_roc_curve{modeltyp
 
 
 
-```{r pub_ready_ROC_uncalibrated}
-# --- 1. Compute per-class ROC curve data ---
-roc_data <- validation_data %>%
-  roc_curve(
-    truth = market_desc,
-    .pred_Jumbo, .pred_Large, .pred_Medium, .pred_Small,
-    case_weights=weighting
-  )
-
-
-roc_dataUW <- validation_data %>%
-  roc_curve(
-    truth = market_desc,
-    .pred_Jumbo, .pred_Large, .pred_Medium, .pred_Small
-  )
-
-
-
-# --- 2. Compute per-class AUC for annotation ---
-auc_dataW <- validation_data %>%
-  roc_auc(
-    truth     = market_desc,
-    .pred_Jumbo, .pred_Large, .pred_Medium, .pred_Small,
-    case_weights=weighting,
-    estimator = "macro"
-  )
-
-
-auc_dataUW <- validation_data %>%
-  roc_auc(
-    truth     = market_desc,
-    .pred_Jumbo, .pred_Large, .pred_Medium, .pred_Small,
-    estimator = "macro"
-  )
-
-# --- 3. Colour palette — four classes ---
-class_colours <- c(
-  "Jumbo"  = "#1B6CA8",   # deep blue
-  "Large"  = "#E05C2A",   # burnt orange
-  "Medium" = "#2E8B57",   # sea green
-  "Small"  = "#7B3F9E"    # purple
-)
-
-# --- 4. Build the figures ---
-p_facet <- ggplot(roc_data,
-                  aes(x = 1 - specificity, y = sensitivity)) +
-  geom_abline(slope = 1, intercept = 0,
-              linetype = "dashed", colour = "grey50", linewidth = 0.4) +
-  geom_path(aes(colour = .level), linewidth = 0.8, show.legend = FALSE) +
-  facet_wrap(~ .level, ncol = 4) +
-  scale_colour_manual(values = class_colours) +
-  scale_x_continuous(
-    name   = "1 \u2212 Specificity (False Positive Rate)",
-    limits = c(0, 1),
-    breaks = seq(0, 1, 0.25),
-    expand = expansion(mult = 0.01)
-  ) +
-  scale_y_continuous(
-    name   = "Sensitivity (True Positive Rate)",
-    limits = c(0, 1),
-    breaks = seq(0, 1, 0.25),
-    expand = expansion(mult = 0.01)
-  ) +
-  coord_equal() +
-  theme_bw(base_size = 9) +
-  theme(
-    strip.background = element_rect(fill = "grey92", colour = "grey40"),
-    strip.text       = element_text(size = 8, face = "bold"),
-    panel.grid.major = element_line(colour = "grey88", linewidth = 0.3),
-    panel.grid.minor = element_blank(),
-    axis.title       = element_text(size = 8),
-    axis.text        = element_text(size = 7, colour = "grey20"),
-    plot.margin      = margin(4, 6, 4, 4, "pt")
-  )
-p_facet
-# --- 5. Save at ICES JMS specifications ---
-ggsave(here("results","ranger","final",glue("validation_nocal_roc_curve{modeltype}{finalfit_vintage}.pdf")),
-       plot   = p_facet,
-       width  = 174,   # mm — double-column, suits 4 facets in a row
-       height = 65,
-       units  = "mm",
-       device = cairo_pdf)
-
-
-
-
-# --- 6. Build the unweighted figure ---
-p_facetUW <- ggplot(roc_dataUW,
-                  aes(x = 1 - specificity, y = sensitivity)) +
-  geom_abline(slope = 1, intercept = 0,
-              linetype = "dashed", colour = "grey50", linewidth = 0.4) +
-  geom_path(aes(colour = .level), linewidth = 0.8, show.legend = FALSE) +
-  facet_wrap(~ .level, ncol = 4) +
-  scale_colour_manual(values = class_colours) +
-  scale_x_continuous(
-    name   = "1 \u2212 Specificity (False Positive Rate)",
-    limits = c(0, 1),
-    breaks = seq(0, 1, 0.25),
-    expand = expansion(mult = 0.01)
-  ) +
-  scale_y_continuous(
-    name   = "Sensitivity (True Positive Rate)",
-    limits = c(0, 1),
-    breaks = seq(0, 1, 0.25),
-    expand = expansion(mult = 0.01)
-  ) +
-  coord_equal() +
-  theme_bw(base_size = 9) +
-  theme(
-    strip.background = element_rect(fill = "grey92", colour = "grey40"),
-    strip.text       = element_text(size = 8, face = "bold"),
-    panel.grid.major = element_line(colour = "grey88", linewidth = 0.3),
-    panel.grid.minor = element_blank(),
-    axis.title       = element_text(size = 8),
-    axis.text        = element_text(size = 7, colour = "grey20"),
-    plot.margin      = margin(4, 6, 4, 4, "pt")
-  )
-p_facetUW
-ggsave(here("results","ranger","final",glue("validation_nocal_UWroc_curve{modeltype}{finalfit_vintage}.pdf")),
-       plot   = p_facetUW,
-       width  = 174,   # mm — double-column, suits 4 facets in a row
-       height = 65,
-       units  = "mm",
-       device = cairo_pdf)
-
-
-
-```
-
-
-
-
-
 
 
 ```{r pub_ready_ROC_calibrated}
+# Note, I'm using the calibrated data, but the calibration cannot change the ROC curve. 
+# The ROC curve depends on the rank orders of the probabilities and the calibration
+# does not change the rank order, the ROC curve on calibrated and uncalibrated data are identical.
+
 # --- 1. Compute per-class ROC curve data ---
 roc_data <- validation_data_isocalib_applied %>%
   roc_curve(
@@ -1050,6 +921,10 @@ ggsave(
 
 
 ```{r pub_ready_test_ROC_calibrated}
+# Note, I'm using the calibrated data, but the calibration cannot change the ROC curve. 
+# The ROC curve depends on the rank orders of the probabilities and the calibration
+# does not change the rank order, the ROC curve on calibrated and uncalibrated data are identical.
+
 # --- 1. Compute per-class ROC curve data ---
 roc_data <- test_data_calibration_applied %>%
   roc_curve(

--- a/writing/out_of_sample_predictions.Rmd
+++ b/writing/out_of_sample_predictions.Rmd
@@ -54,6 +54,7 @@ The model is finalized with final_fit and calibrated with "calibration and valid
  
  --->
 ```{r global_options, include=FALSE}
+search_type<-"Advanced"
 
 modeltype<-params$modeltype
 
@@ -121,11 +122,9 @@ if (runClass %in% c('Local', 'Windows')){
   my.parallel.threads<-parallel::detectCores() -2 
 } else if (runClass %in% c('Container','DynamicContainer')){ 
 					  
-												
-  my.parallel.threads<-2
-  
+	my.parallel.threads<-1											
 }
-my.ranger.threads<-7
+my.ranger.threads<-22
 
 here::i_am("writing/out_of_sample_predictions.Rmd")
 
@@ -199,16 +198,8 @@ read in the final model, extract the recipe and the predictors. Read in the prob
 final_fit<-read_rds(file=here("results","ranger",glue("{final_pattern}{tuning_vintage}.Rds")))
 
 
-# What is the workflow
-final_workflow<-extract_workflow(final_fit)
-
-# And the recipe
-extract_recipe(final_fit)
-
-preds<-final_fit$.workflow[[1]]$pre$actions$recipe$recipe$var_info %>%
- dplyr::filter(role=="predictor")
-
-num_preds<-nrow(preds)
+# What the recipe
+classification_recipe<-extract_recipe(final_fit)
 
 
 # Read in the out-of-sample data
@@ -240,7 +231,7 @@ Apply the final RF model to the data. Calibrate the probabilities
 
 ```{r Validation_predictions}
 # Apply the Final fit to the out of sample dataset that I feel confident about 
-oos_predictable <- augment(final_workflow,oos_predictable)
+oos_predictable <- augment(final_fit,oos_predictable)
 
 
 # Apply calibration apply to the out-of-sample dataset

--- a/writing/predictions_heatmap.Rmd
+++ b/writing/predictions_heatmap.Rmd
@@ -42,6 +42,7 @@ Construct hard and soft predictive heatmaps.  Hard will go into the Appendix, so
  
  --->
 ```{r global_options, include=FALSE}
+search_type<-"Advanced"
 
 modeltype<-params$modeltype
 
@@ -189,8 +190,6 @@ train_data <- training(data_split)
 validation_data <- validation(data_split)
 
 source(here("R_code","analysis","fit_random_forest","BSB.Classification.Recipe.R"))
-search_type<-"Initial"
-
 
 source(here("R_code","analysis","fit_random_forest","BSB.Workflow.Setup.R"))
 
@@ -206,31 +205,14 @@ read in the final model, extract the recipe and the predictors, extract the pred
 
 final_fit<-read_rds(file=here("results","ranger",glue("{final_pattern}{tuning_vintage}.Rds")))
 
-
-# What is the workflow
-final_workflow<-extract_workflow(final_fit)
-
-# And the recipe
-extract_recipe(final_fit)
-
-preds<-final_fit$.workflow[[1]]$pre$actions$recipe$recipe$var_info %>%
- dplyr::filter(role=="predictor")
-
-num_preds<-nrow(preds)
-
-final_predictions<-final_fit %>%
-  collect_predictions()
+# What the recipe
+classification_recipe<-extract_recipe(final_fit)
 
 # pull the probability names
 prob_names<-colnames(predictions) 
 prob_names<-grep("^\\.pred_", prob_names, value=TRUE)
 prob_names<-grep("^\\.pred_class", prob_names, value=TRUE, invert=TRUE)
 
-
-# look at the fit metrics
-final_fit_metrics<-final_fit %>%
-  collect_metrics()
-final_fit_metrics
 
 # all.metrics %>%
 #   dplyr::filter(.config==best_config) 
@@ -253,7 +235,7 @@ Make the heat maps (confusion matrices).
 ```{r Validation_predictions}
 # Load in the validation data
 
-test_data <- augment(final_workflow,test_data)
+test_data <- augment(final_fit,test_data)
 
 ```
 


### PR DESCRIPTION
updates alot of the processing pipeline after uncounting()

1. Use butcher on the trained workflow to save disk space.
2. Print the Goodness of fit metrics on the trained data. These are not useful for anything except a sanity check. The model fit statistics should be very high
3. Print goodness of fit metric on the "calibration dataset"
4. Add an extra .R doc to compute the variable importance. This also graphs the Variable Importance.
5. remove the nocalibration ROC curves (redundant)

And then, I had to fit the ranger model directly to save space. the "expanded" version takes a ton of memory (90gb, but then it hit 150gb) i think during predictions.